### PR TITLE
Change dependency version requirements to be "here to next major"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.10"
+python = ">=3.9, <3.11"
 matplotlib = ">=3.4.3"
-palettable = "3.3.0"
-seaborn = "0.11.2"
-pandas = "1.4.1"
+palettable = "^3.3.0"
+seaborn = "^0.11.2"
+pandas = "^1.4.1"
 scipy = "^1.8.0"
 sklearn = "^0.0"
 numpy = "^1.22.3"
@@ -17,13 +17,16 @@ Sphinx = {version = "^4.5.0", optional = true}
 sphinx-rtd-theme = {version = "^1.0.0", optional = true}
 
 [tool.poetry.dev-dependencies]
-spyder-kernels = ">=2.1.0,<2.2.0"
+spyder-kernels = "^2.1.0"
 pytest = "^7.1.0"
 Sphinx = "^4.5.0"
 sphinx-rtd-theme = "^1.0.0"
 
 [tool.poetry.extras]
 docs = ["Sphinx", "sphinx-rtd-theme"]
+
+[tool.poetry.scripts]
+prive = "prive.run:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Version requirements are now specified as, for example,
pandas = "^1.4.1" where the caret means "from this version
up to the next major version number increment."