### PR TITLE
added initial version of contributing markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to Prive
+
+Welcome to Prive the synthetic data privacy toolbox from The Alan Turing Institute.
+
+We encourage everyone to use our package to run privacy tests on their own
+datasets using standard generating methods, and to test their new synthetic
+generating methods on new or standard datasets.
+
+We welcome contributions either to improve our tooling 
+fix bugs or add new features.
+
+We would also support adding your own: 
+- Privacy Attacks 
+- Threat Models
+- Dataset types
+- Synthetic Generators
+
+We encourage the standard use of Github Issues and pull requests and subsequent reviews. 
+
+
+


### PR DESCRIPTION
This is not ready to merge yet, but i thought we could use this pull request to discuss how we want to structure the contributing guidelines for the project in `CONTRIBUTING.md`.

The contributor guide for the
[Turing Way](https://github.com/alan-turing-institute/the-turing-way/blob/main/CONTRIBUTING.md) would seem to be a good place to reference
