### PR TITLE
86 adding simple attacks

### DIFF
--- a/docs/source/implementing-attacks.rst
+++ b/docs/source/implementing-attacks.rst
@@ -40,11 +40,13 @@ This *can* take a dataset description as argument, although it is better not to.
 
 ``generate_training_samples``
 
+``TrainableThresholdAttack``
+
 
 
 Set Classifiers
 ---------------
 
-For attacks based on *shadow modelling*, the base class of
+For attacks based on *shadow modelling*, the base class of 
 
 ``GroundhogAttack``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,6 +64,7 @@ Contents
    quickstart
    dataset-schema
    modelling-threats
+   library-of-attacks
    implementing-attacks
 
 

--- a/docs/source/library-of-attacks.rst
+++ b/docs/source/library-of-attacks.rst
@@ -7,10 +7,49 @@ For this reason, ``PrivE`` implements a large range of attacks.
 While some of these attacks are technically involved, many are straightforward and are intended mostly as safety checks.
 We here present the different attacks implemented in ``PrivE``, grouped by theme. For each attack, we specify the additional parameters it requires, and the attack models (see `Modelling Threats <modelling-threats.rst>`) it applies to.
 ``PrivE`` attacks inherit from the ``prive.attacks.Attack`` abstract class (see `Implementing Attacks <implementing-attacks.rst>` for details).
-Note that the constuctor of *all* the attacks described below allows for an optional ``label`` parameters, which we exclude from the descriptions for the sake of concision.
+Note that the constructor of *all* the attacks described below allows for an optional ``label`` parameters, which we exclude from the descriptions for the sake of concision.
 
 *Notations*: we denote by :math:`D^{(r)}` the real, private dataset, and :math:`D^{(s)}` the synthetic dataset obtained with the generation method :math:`\mathcal{G}`. For targeted attacks, the attacker aims to learn information about a record :math:`x`, either membership (:math:`x \in D^{(r)}`) or the value of a sensitive attribute :math:`s` (:math:`v~\text{s.t.}~x|v \in D^{(r)}`).
 
+Summary
+-------
+
+.. list-table::
+	:widths: 10 10 10 70
+	:header-rows: 1
+
+	* - Class
+	  - Threat Model
+	  - Parameters
+	  - Decision uses
+	* - ``ClosestDistanceMIA``
+	  - MIA
+	  - ``distance``, ``criterion``
+	  - Distance of closest record to target record :math:`x` in :math:`D^{(s)}`.
+	* - ``ClosestDistanceAIA``
+	  - AIA
+	  - ``distance``, ``criterion``
+	  - For each value, distance of closest record to target record :math:`x|b` in :math:`D^{(s)}`.
+	* - ``LocalNeighbourhoodAttack``
+	  - MIA/AIA
+	  - ``distance``, ``radius``, ``criterion``
+	  - Sphere of given radius around the target record, :math:`B[x,radius]`. For MIA, use the fraction of records that are in the sphere. For AIA, use the fraction of records in the sphere with a given value :math:`v`.
+	* - ``ShadowModellingAttack``
+	  - MIA/AIA
+	  - ``SetClassifier``
+	  - Train a set classifier :math:`\mathcal{F}_\theta` from pairs :math:`(D^{(r)}_i, D^{(s)}_i)` to predict membership or the sensitive attribute for the sensitive data.
+	* - ``GroundhogAttack``
+	  - MIA/AIA
+	  - ``features``, ``classifier``
+	  - Shadow modelling attack using a random forest classifier over simple features extracted from datasets, proposed by Stadler et al. [1]_.
+	* - ``ProbabilityEstimationAttack``
+	  - MIA
+	  - ``estimator``, ``criterion``
+	  - Density estimator fit on synthetic records :math:`p_\theta`, and the density estimated in the target record :math:`p_\theta(x)`.
+	* - ``SyntheticPredictorAttack``
+	  - AIA
+	  - ``estimator``, ``criterion``
+	  - Classifier fit on synthetic records to predict the sensitive attribute :math:`x_s` from other attributes :math:`x_{-s}`.
 
 Trainable-threshold attacks
 ---------------------------
@@ -24,6 +63,8 @@ The constructor of these attacks takes an argument ``criterion`` that describes 
 - ``criterion = ("tp", value)``: the threshold is selected such that the true positive rate of the method is approximately equal to ``value``.
 - ``criterion = ("fp", value)``: (similarly, but for the false positive rate).
 - ``criterion = ("threshold", value)``: the threshold is set to ``value``. In this case, no further training is required.
+
+*Note*: this attack generally applies to the black-box setting, but if ``criterion[0] = "threshold"``, then the attack can be applied *without* access to the generator (the no-box setting).
 
 
 Closest-distance Attacks
@@ -72,7 +113,7 @@ For attribute inference, the score for value :math:`v` is the fraction of record
 Parameters:
 
 - ``distance``: a ``DistanceMetric`` object describing the distance to use between records.
-- ``radius``: nonnegative float, the radius of the local neighbourhood.
+- ``radius``: non-negative float, the radius of the local neighbourhood.
 - ``criterion`` (see `above <Trainable-threshold attacks>`_).
 
 
@@ -80,28 +121,106 @@ Parameters:
 Shadow Modelling Attacks
 ------------------------
 
-Shadow modelling is a technique th
-Intuitively, 
-This technique has been used for synthetic data in the paper by Stadler et al.
-Groundhog [1]_
+Shadow modelling is a common technique to build privacy attacks against privacy-enhancing technologies.
+The idea is to generate a large number of training "real" datasets :math:`(D_1^{(r)}, \dots, D_N^{(r)})` according to the attacker's knowledge (usually as subsets from an auxiliary dataset), then generate synthetic datasets from each of these: :math:`(D_1^{(s)}, \dots, D_N^{(s)})`.
+For a function :math:`\phi` that the attacker is trying to learn (e.g., :math:`phi(D) = I\{x \in D\})`), they train a machine learning model :math:`\mathcal{F}_\theta` to infer the value of :math:`\phi` over real datasets from the synthetic dataset: :math:`\mathcal{F}_\theta(D^{(s)}) = \phi(D^{(r)})`.
+
+The key design decision of a shadow modelling attack (``prive.attacks.ShadowModellingAttack``) is in the choice of the classifier :math:`\mathcal{F}_\theta`.
+A challenge of applying shadow modelling to synthetic datasets is that the input of the classifier is *the whole synthetic dataset*, and is thus very high-dimensional.
+The first attack using shadow modelling for synthetic data is by Stadler et al.[1]_, an attack which we refer to as the Groundhog attack (``prive.attacks.GroundhogAttack``).
+
 
 ShadowModellingAttack
 ~~~~~~~~~~~~~~~~~~~~~
 
-Requires
+This class implements the logic of shadow modelling (in ``.train`` and ``.attack``) for membership and attribute inference attacks.
+It takes one parameter, ``classifier``, a ``SetClassifier`` object that represents a classifier over *sets*.
+
+A ``SetClassifier`` has an interface similar to ``scikit-learn`` classifiers, with ``.fit``, ``.predict`` and ``.predict_proba`` methods, except the inputs are lists of ``prive.datasets.Dataset`` objects.
+
+
+FeatureBasedSetClassifier
++++++++++++++++++++++++++
+
+The main ``SetClassifier`` implemented by ``PrivE`` is ``FeatureBasedSetClassifier``, a classifier that groups together two independent components:
+
+1. ``features``: A ``SetFeature`` object that extracts a vector of features (a ``numpy.array``) from a ``Dataset``. This object is a fixed function :math:`psi` and is not trainable.
+2. ``classifier``: A classifier from ``scikit-learn``, :math:`C_\theta`. This classifier is then trained (choosing :math:`\theta`) to infer the sensitive function :math:`\phi(D)` from the features extracted from a dataset.
+
+The corresponding classifier is obtained by combining these two elements as :math:`\mathcal{F}_\theta = C_\theta \circ \psi`.
+
+``SetFeature`` objects primarily consist of a ``.extract`` method mapping datasets to a ``numpy.array`` of size (len(datasets), k) for some size k. Implementing a custom ``SetFeature`` only requires to create an object inhering from ``prive.attacks.SetFeature`` and defining the ``.extract`` method.
+``PrivE`` implements several simple ``SetFeature``.
+
+.. list-table::
+	:widths: 20 20 60
+	:header-rows: 1
+
+	* - Class
+	  - Parameters
+	  - Description
+	* - ``NaiveSetFeature``
+	  - /
+	  - Computes the median, mean and variance of each column, with categorical columns 1-hot encoded. This is :math:`F_\text{naive}` from [1]_.
+	* - ``HistSetFeature``
+	  - :math:`n_\text{bins} =10`, :math:`bounds = (0,1)`
+	  - Computes histograms for each attribute. For continuous attributes, the histogram is computed with :math:`n_\text{bins}`, over the interval :math:`bounds`. This is :math:`F_\text{hist}` from [1]_.
+	* - ``CorrSetFeature``
+	  - /
+	  - Computes the correlation coefficient between all attributes, with categorical columns 1-hot encoded. This is :math:`F_\text{corr}` from [1]_.
+
 
 GroundhogAttack
 ~~~~~~~~~~~~~~~
 
+This class implements the attack from Stadler et al.[1]_. In ``PrivE``, this is a ``FeatureBasedSetClassifier`` with, by default:
+
+1. ``feature = NaiveSetFeature() + HistSetFeature() + CorrSetFeature()``
+2. ``classifier = sklearn.ensemble.RandomForestClassifier()``.
+
+The behaviour of this attack can be modified with four optional parameters:
+
+- ``use_naive``: boolean, whether to use the Naive feature set (default True).
+- ``use_hist``: boolean, whether to use the Histogram feature set (default True).
+- ``use_corr``: boolean, whether to use the Correlations feature set (default True).
+- ``model``: a ``scikit-learn`` classifier to use instead of the random forest (default None).
+
+
 Inference-on-Synthetic Attacks
 ------------------------------
 
-Link to CAP [2]_
+Inference-on-Synthetic attacks consist of attacks that make inference on the target record :math:`x` from a machine learning model trained on the synthetic data.
+These are simple attacks based on traditional ``scikit-learn`` models, and are all instances of ``TrainableThresholdAttack``.
+
+ProbabilityEstimationAttack
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Probability-Estimation attacks are membership inference attacks that use a density estimator fit to the synthetic data, :math:`p_\theta`. The score used by the attack is the density estimated in the target point, :math:`p_\theta(x)`. The intuition is that the presence of :math:`x` in the real dataset will bias the distribution from which synthetic records are sampled in such a way that synthetic records are more likely to "look like" :math:`x`.
+The density estimated on the synthetic data can be seen as an approximation of the density of the generating distribution.
+
+Parameters:
+
+- ``estimator``: a ``DensityEstimator`` object, or a kernel density estimator from ``scikit-learn``.
+- ``criterion`` (see `above <Trainable-threshold attacks>`_).
+
+``DensityEstimator`` objects implement a ``.fit`` method, training parameters :math:`\theta` from a dataset, and a ``.score`` method, returning a density :math:`y\in\mathbb{R}` for records :math:`y`.
+The main ``DensityEstimator`` provided by ``PrivE`` is the internal class ``sklearnDensityEstimator``, which wraps a ``scikit-learn`` density estimator, and is used by the constructor of ``ProbabilityEstimationAttack``.
+
+
+SyntheticPredictorAttack
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Synthetic predictor attacks are attribute inference attacks that train a machine learning model to predict the value of :math:`x_s` from known attributes :math:`x_{-s}`, :math:`C_\theta`, on records in the synthetic data. This is a common privacy attack, where correlations between attributes are exploited to predict the sensitive attribute (see, e.g., Correct Attribution Probability CAP [2]_). However, whether such attacks present a privacy risk is controversial, as an attacker can make a guess with accuracy better than random *even if* the target user is not in the dataset. ``PrivE`` circumvents this issue by randomising the sensitive attribute independently from other attributes.
+
+Disclaimer
+
+- ``estimator``: a ``scikit-learn`` classifier to infer the sensitive attribute from other attributes. Categorical attributes of the data are 1-hot encoded before learning, so any classifier on real-valued data can be applied.
+- ``criterion`` (see `above <Trainable-threshold attacks>`_).
 
 
 References
 ----------
 
-.. TODO: add the Usenix reference when it comes out.
+.. TODO: add the Usenix reference when the paper comes out.
 .. [1] Stadler, T., Oprisanu, B. and Troncoso, C., 2021. Synthetic data–anonymisation groundhog day. arXiv preprint arXiv:2011.07018.
 .. [2] Elliot, M., 2015. Final report on the disclosure risk associated with the synthetic data produced by the sylls team. Report 2015, 2.

--- a/docs/source/library-of-attacks.rst
+++ b/docs/source/library-of-attacks.rst
@@ -1,0 +1,107 @@
+==================
+Library of Attacks
+==================
+
+Adversarial approaches for privacy require auditors to run a large range of diverse attacks, in order to test for as many potential vulnerabilities as possible.
+For this reason, ``PrivE`` implements a large range of attacks.
+While some of these attacks are technically involved, many are straightforward and are intended mostly as safety checks.
+We here present the different attacks implemented in ``PrivE``, grouped by theme. For each attack, we specify the additional parameters it requires, and the attack models (see `Modelling Threats <modelling-threats.rst>`) it applies to.
+``PrivE`` attacks inherit from the ``prive.attacks.Attack`` abstract class (see `Implementing Attacks <implementing-attacks.rst>` for details).
+Note that the constuctor of *all* the attacks described below allows for an optional ``label`` parameters, which we exclude from the descriptions for the sake of concision.
+
+*Notations*: we denote by :math:`D^{(r)}` the real, private dataset, and :math:`D^{(s)}` the synthetic dataset obtained with the generation method :math:`\mathcal{G}`. For targeted attacks, the attacker aims to learn information about a record :math:`x`, either membership (:math:`x \in D^{(r)}`) or the value of a sensitive attribute :math:`s` (:math:`v~\text{s.t.}~x|v \in D^{(r)}`).
+
+
+Trainable-threshold attacks
+---------------------------
+
+Many attacks rely on a fixed (non-trained) score function :math:`s: (D^{(s)}, x) \rightarrow \mathbb{R}`. The decision (``.attack``) thus takes the form of a threshold on this score, :math:`\mathcal{A}(D^{(s)}, x) = 1 \Leftrightarrow s(D^{(s)}, x) \geq \tau`, i.e. predicting the positive class if and only if the score is above some threshold :math:`\tau`. This threshold can be selected empirically from observing a large enough set of training datasets for which the attack target (e.g., membership of :math:`x`) is known.
+
+The partially abstract class ``TrainableThresholdAttack`` extends ``Attack`` to represent these score-based attacks. It implements the ``train`` and ``attack`` methods of ``Attack``, based on an attack-specific ``.attack_score`` to be implemented. Many of the attacks described below extend this class.
+The constructor of these attacks takes an argument ``criterion`` that describes how the threshold should be selected. This argument should be a tuple, where the first entry describes the general criterion, and other entries provide additional information if needed. There are four options:
+
+- ``criterion = ("accuracy",)``: the threshold is selected to approximately maximise the accuracy of ``.attack``.
+- ``criterion = ("tp", value)``: the threshold is selected such that the true positive rate of the method is approximately equal to ``value``.
+- ``criterion = ("fp", value)``: (similarly, but for the false positive rate).
+- ``criterion = ("threshold", value)``: the threshold is set to ``value``. In this case, no further training is required.
+
+
+Closest-distance Attacks
+------------------------
+
+Closest-distance Attacks are *targeted attacks* that rely on the local neighbourhood of the target record in the synthetic data to infer information.
+A simple example is a direct lookup attack, where the attacker predicts that the target record is in the real data if and only if it is also found in the *synthetic* data :math:`x \in D^{(s)}`.
+They exploit the fact that real records have a higher likelihood to be found in the synthetic data, especially if the generation method is poorly designed (e.g., it is overfitted).
+These attacks require a meaningful notion of distance between records in a dataset, represented by a ``prive.attacks.DistanceMetric`` object. While ``PrivE`` only implements two simple distances (``HammingDistance`` and ``LpDistance``), this object is little more than a wrapper over ``__call__`` and custom distance metrics are straightforward to implement.
+
+
+ClosestDistanceMIA
+~~~~~~~~~~~~~~~~~~
+
+This membership inference attack uses the minimal distance between the target record and records in the synthetic dataset as (minus the) score: :math:`s(D^{(s)}, x) = - \min_{y \in D^{(s)}} distance(x, y)`. The negation of the distance is used instead, as a positive score indicates higher likelihood of membership.
+This attack can be seen as a generalisation of direct-lookup attacks.
+
+Parameters:
+
+- ``distance``: a ``DistanceMetric`` object describing the distance to use between records.
+- ``criterion`` (see `above <Trainable-threshold attacks>`_).
+
+
+ClosestDistanceAIA
+~~~~~~~~~~~~~~~~~~
+
+Similarly, this attribute inference attack uses a score proportional to the minimal distance between the target record and records in the synthetic dataset, for each possible value of the sensitive attribute: :math:`s_v' = - \min_{y\in D^{(s)}} distance(x|v, y)`. The actual score is normalised, so as to give the *relative* distance for one value: :math:`s_v = \frac{s_v'}{\sum_u s_u'}`. In the case where there are only two values, the score is :math:`s := s_1 = \frac{s_1'}{s_1' + s_0'}`, and using a threshold of :math:`\tau = 0.5` is equivalent to choosing the value with smallest minimal distance.
+
+Note that the above is more complex than the more intuitive idea of finding the record that is closest to the known attributes of the target record :math:`y \in \arg\min_{y\in D^{(s)}} x_{-s}` and using its value :math:`y_s` as answer. The approaches are however equivalent for any distance function that is space-invariant for the sensitive attribute, :math:`d(x|v, x|u) = f(v,u)~\forall x`, and more accurate for distances that do not satisfy this condition.
+
+Parameters:
+
+- ``distance``: a ``DistanceMetric`` object describing the distance to use between records.
+- ``criterion`` (see `above <Trainable-threshold attacks>`_).
+
+
+LocalNeighbourhoodAttack
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This attack, which can be used for both membership and attribute inference, uses the local neighbourhood of the target record in :math:`D^{(s)}` for the attack. This local neighbourhood is defined as the ball around `x` for a specific radius `r`, :math:`B[x,r] = \left\{y \in D^{(s)}: distance(x,y) \leq r\right\}`.
+
+For membership inference, the score is the fraction of all records of :math:`D^{(s)}` that are also in :math:`B[x,r]`. The intuition is that if :math:`x` is in the real data, it is likely that similar records will be generated.
+
+For attribute inference, the score for value :math:`v` is the fraction of records in :math:`B[x,r]` that have that value. Similarly, the idea is that if :math:`x` has value :math:`v` in the real data, then records similar to :math:`x` in the synthetic dataset are more likely to have value :math:`v`.
+
+Parameters:
+
+- ``distance``: a ``DistanceMetric`` object describing the distance to use between records.
+- ``radius``: nonnegative float, the radius of the local neighbourhood.
+- ``criterion`` (see `above <Trainable-threshold attacks>`_).
+
+
+
+Shadow Modelling Attacks
+------------------------
+
+Shadow modelling is a technique th
+Intuitively, 
+This technique has been used for synthetic data in the paper by Stadler et al.
+Groundhog [1]_
+
+ShadowModellingAttack
+~~~~~~~~~~~~~~~~~~~~~
+
+Requires
+
+GroundhogAttack
+~~~~~~~~~~~~~~~
+
+Inference-on-Synthetic Attacks
+------------------------------
+
+Link to CAP [2]_
+
+
+References
+----------
+
+.. TODO: add the Usenix reference when it comes out.
+.. [1] Stadler, T., Oprisanu, B. and Troncoso, C., 2021. Synthetic data–anonymisation groundhog day. arXiv preprint arXiv:2011.07018.
+.. [2] Elliot, M., 2015. Final report on the disclosure risk associated with the synthetic data produced by the sylls team. Report 2015, 2.

--- a/examples/attribute_inference.py
+++ b/examples/attribute_inference.py
@@ -1,0 +1,67 @@
+"""
+This example is similar to multiple_attacks.py, except that it applies
+attribute inference attacks (AIA) instead. AIAs are generally used in cases
+where membership is not a meaningful threat.
+
+The PrivE interface for AIAs is similar to MIAs, except one must also specify
+a sensitive attribute to guess, and a set of possible values. Many attacks
+in PrivE apply seemlessly to either AI and MI, so little change is required.
+
+"""
+
+import prive.datasets
+import prive.generators
+import prive.threat_models
+import prive.attacks
+import prive.report
+
+from sklearn.linear_model import LogisticRegression
+
+# Load the data.
+data = prive.datasets.TabularDataset.read(
+    "data/2011 Census Microdata Teaching File", label="Census"
+)
+
+# Create a dummy generator.
+generator = prive.generators.Raw()
+
+# Select the auxiliary data + black-box attack model.
+data_knowledge = prive.threat_models.AuxiliaryDataKnowledge(
+    data, auxiliary_split=0.5, num_training_records=1000,
+)
+
+sdg_knowledge = prive.threat_models.BlackBoxKnowledge(
+    generator, num_synthetic_records=1000,
+)
+
+threat_model = prive.threat_models.TargetedAIA(
+    attacker_knowledge_data=data_knowledge,
+    # Specific to AIA: the sensitive attribute and its possible values.
+    sensitive_attribute="Sex",
+    attribute_values=["1", "2"],
+    target_record=data.get_records([0]),
+    attacker_knowledge_generator=sdg_knowledge,
+)
+
+# We here create a range of attacks to test.
+attacks = [
+    prive.attacks.GroundhogAttack(),
+    prive.attacks.ClosestDistanceAIA(criterion="accuracy"),
+    prive.attacks.ClosestDistanceAIA(
+        distance=prive.attacks.LpDistance(2), criterion="accuracy"
+    ),
+    prive.attacks.LocalNeighbourhoodAttack(radius=1),
+    prive.attacks.LocalNeighbourhoodAttack(radius=2),
+    prive.attacks.SyntheticPredictorAttack(LogisticRegression(), criterion="accuracy"),
+]
+
+# Train, evaluate, and summarise all attacks.
+results = []
+for attack in attacks:
+    print(f"Evaluating attack {attack.label}...")
+    attack.train(threat_model, num_samples=100)
+    results.append(threat_model.test(attack, num_samples=100))
+
+import numpy as np
+for yt, yp in results:
+	print(np.mean(yt==yp))

--- a/examples/multiple_attacks.py
+++ b/examples/multiple_attacks.py
@@ -11,6 +11,8 @@ import prive.threat_models
 import prive.attacks
 import prive.report
 
+from prive.attacks import LpDistance
+
 import pandas
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier
@@ -50,7 +52,8 @@ attacks = [
     groundhog(prive.attacks.HistSetFeature(), RandomForestClassifier(n_estimators=100)),
     groundhog(prive.attacks.CorrSetFeature(), RandomForestClassifier(n_estimators=100)),
     groundhog(prive.attacks.CorrSetFeature(), LogisticRegression()),
-    prive.attacks.ClosestDistanceAttack(criterion="accuracy"),
+    # prive.attacks.ClosestDistanceAttack(criterion="accuracy"),
+    prive.attacks.ClosestDistanceAttack(distance=LpDistance(2), criterion="accuracy")
 ]
 
 attack_names = [

--- a/examples/multiple_attacks.py
+++ b/examples/multiple_attacks.py
@@ -17,6 +17,7 @@ import pandas
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.neighbors import KernelDensity
 
 # Load the data.
 data = prive.datasets.TabularDataset.read(
@@ -58,11 +59,14 @@ attacks = [
     prive.attacks.GroundhogAttack(
         model=LogisticRegression(), label="LogisticGroundhog"
     ),
-    prive.attacks.ClosestDistanceAttack(
+    prive.attacks.ClosestDistanceMIA(
         criterion="accuracy", label="ClosestDistance-Hamming"
     ),
-    prive.attacks.ClosestDistanceAttack(
+    prive.attacks.ClosestDistanceMIA(
         distance=LpDistance(2), criterion="accuracy", label="ClosestDistance-L2"
+    ),
+    prive.attacks.ProbabilityEstimationAttack(
+        KernelDensity(), criterion="accuracy", label="KernelEstimator"
     ),
 ]
 

--- a/examples/multiple_attacks.py
+++ b/examples/multiple_attacks.py
@@ -50,7 +50,7 @@ attacks = [
     groundhog(prive.attacks.HistSetFeature(), RandomForestClassifier(n_estimators=100)),
     groundhog(prive.attacks.CorrSetFeature(), RandomForestClassifier(n_estimators=100)),
     groundhog(prive.attacks.CorrSetFeature(), LogisticRegression()),
-    prive.attacks.ClosestDistanceAttack(fpr=0.1),
+    prive.attacks.ClosestDistanceAttack(criterion="accuracy"),
 ]
 
 attack_names = [

--- a/examples/multiple_attacks.py
+++ b/examples/multiple_attacks.py
@@ -63,6 +63,9 @@ attacks = [
         criterion="accuracy", label="ClosestDistance-Hamming"
     ),
     prive.attacks.ClosestDistanceMIA(
+        criterion=("threshold", 0), label="Direct Lookup"
+    ),
+    prive.attacks.ClosestDistanceMIA(
         distance=LpDistance(2), criterion="accuracy", label="ClosestDistance-L2"
     ),
     prive.attacks.ProbabilityEstimationAttack(

--- a/prive/attacks/__init__.py
+++ b/prive/attacks/__init__.py
@@ -4,6 +4,7 @@ from .closest_distance import (
     ClosestDistanceAIA,
     LocalNeighbourhoodAttack,
 )
+from .distances import DistanceMetric, HammingDistance, LpDistance
 from .direct_linkage import DirectLinkage
 from .shadow_modelling import ShadowModellingAttack
 from .set_classifiers import (
@@ -14,6 +15,11 @@ from .set_classifiers import (
     HistSetFeature,
     CorrSetFeature,
 )
-from .distances import DistanceMetric, HammingDistance, LpDistance
+from .synthinference import (
+    ProbabilityEstimationAttack,
+    DensityEstimator,
+    sklearnDensityEstimator,
+    SyntheticPredictorAttack,
+)
 from .groundhog import GroundhogAttack
 from .utils import load_attack

--- a/prive/attacks/__init__.py
+++ b/prive/attacks/__init__.py
@@ -1,5 +1,9 @@
 from .base_classes import Attack
-from .closest_distance import ClosestDistanceAttack
+from .closest_distance import (
+    ClosestDistanceMIA,
+    ClosestDistanceAIA,
+    LocalNeighbourhoodAttack,
+)
 from .direct_linkage import DirectLinkage
 from .shadow_modelling import ShadowModellingAttack
 from .set_classifiers import (

--- a/prive/attacks/__init__.py
+++ b/prive/attacks/__init__.py
@@ -15,11 +15,11 @@ from .set_classifiers import (
     HistSetFeature,
     CorrSetFeature,
 )
+from .groundhog import GroundhogAttack
 from .synthinference import (
     ProbabilityEstimationAttack,
     DensityEstimator,
     sklearnDensityEstimator,
     SyntheticPredictorAttack,
 )
-from .groundhog import GroundhogAttack
 from .utils import load_attack

--- a/prive/attacks/__init__.py
+++ b/prive/attacks/__init__.py
@@ -10,4 +10,5 @@ from .set_classifiers import (
     HistSetFeature,
     CorrSetFeature,
 )
+from .distances import DistanceMetric, HammingDistance, LpDistance
 from .utils import load_attack

--- a/prive/attacks/base_classes.py
+++ b/prive/attacks/base_classes.py
@@ -3,6 +3,16 @@ Abstract base classes for various privacy attacks.
 
 """
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from ..datasets import Dataset
+    from ..threat_models import ThreatModel
+
+from ..threat_models import LabelInferenceThreatModel
+
 from abc import ABC, abstractmethod
 
 
@@ -21,7 +31,7 @@ class Attack(ABC):
     """
 
     @abstractmethod
-    def train(self, threat_model):
+    def train(self, threat_model: ThreatModel):
         """
         Train parameters of the attack.
 
@@ -29,7 +39,7 @@ class Attack(ABC):
         pass
 
     @abstractmethod
-    def attack(self, datasets):
+    def attack(self, datasets: list[Dataset]):
         """
         Perform the attack on each dataset in a list and return a (discrete) decision.
 
@@ -37,7 +47,7 @@ class Attack(ABC):
         pass
 
     @abstractmethod
-    def attack_score(self, datasets):
+    def attack_score(self, datasets: list[Dataset]):
         """
         Perform the attack on each dataset in a list, but return a confidence
         score (specifically for classification tasks).
@@ -46,8 +56,139 @@ class Attack(ABC):
         pass
 
 
-# TODO(design)
-# For later discussion: not sure if we want to keep classes for different types
-#  of attacks. For instance, we can implement the Groundhog attack for MIAs and
-#  AIAs with the exact same code (since the sampling logic of train/test is in
-#  the threat model).
+# Many attacks are based around an `attack_score` (potentially trainable), with
+# the decision threshold then tailored for a specific task, e.g., max accuracy,
+# matching a given true positive rate or true negative rate. We here implement
+# a generic class that implements threshold selection for a generic score.
+
+import numpy as np
+from sklearn.metrics import roc_curve
+
+
+class TrainableThresholdAttack(Attack):
+    """
+    Generic class to represent attacks that rely on a score, combined with a
+    threshold that is chosen according to some (fairly generic) criterion.
+    Many attacks should fall under this 
+
+    """
+
+    # To implement a specific attack from this generic class, you must
+    # instantiate the `attack_score` function from Attack. Additionally,
+    # you may implement _train_attack_score if relevant.
+
+    def __init__(self, criterion: tuple):
+        """
+        Initialise this attack with a given threshold-selection criterion.
+
+        The criterion is a tuple with at least one entry. The first entry,
+        criterion[0], is the target criterion (accuracy/tp/fp/threshold).
+        Further entries give additional information on the target.
+
+        Acceptable criterions are:
+         - ("accuracy",): choose the threshold that yields maximum accuracy.
+         - ("tp", float): choose the threshold that yields as close as possible
+            to a given true positive ("tp") rate.
+         - ("fp", float): similarly, for the false positive rate ("fp").
+         - ("threshold", float): manually specify the threshold.
+
+        """
+        if not isinstance(criterion, tuple):
+            # We actually allow for criterion = "accuracy", as it is cleaner.
+            assert criterion == "accuracy", "Criterion should be a tuple."
+            criterion = ("accuracy",)
+        # Parse the criterion into target_criterion and target_value.
+        self.target_criterion = criterion[0]
+        if self.target_criterion != "accuracy":
+            assert len(criterion) == 2, "Missing second argument to criterion."
+            self.target_value = criterion[1]
+        # Initialise the threshold.
+        self._threshold = None
+        if self.target_criterion == "threshold":
+            self._threshold = self.target_value
+
+    def train(
+        self,
+        threat_model: LabelInferenceThreatModel,
+        num_samples: int = 100,
+        **attack_score_kwargs
+    ):
+        """
+        Train this attack: train the score, then choose a threshold meeting
+        the target criterion.
+
+        Parameters
+        ----------
+        threat_model: LabelInferenceThreatModel
+            The threat model from which to generate labelled samples.
+        num_samples: int (default, 100).
+            Number of training samples to generate to select the threshold.
+        (optionally), additional keyword arguments, passed to _train_attack_score.
+        """
+        # First, optionally train the score.
+        assert isinstance(
+            threat_model, LabelInferenceThreatModel
+        ), "Threat model must be a LabelInferenceThreatModel."
+        self.threat_model = threat_model
+        self._train_attack_score(threat_model, num_samples, **attack_score_kwargs)
+        # Then, compute the scores for a number of training datasets.
+        if self._threshold is not None:
+            return  # No training required.
+        # If the threshold is not specified, train to get the desired tpr or fpr.
+        synthetic_datasets, labels = self.threat_model.generate_training_samples(
+            num_samples
+        )
+        # Finally, compute the ROC curve and select the threshold from it.
+        fpr_all, tpr_all, thresholds = roc_curve(
+            labels, self.attack_score(synthetic_datasets)
+        )
+        # Select the threshold such that the criterion is matched.
+        if self.target_criterion == "fpr":
+            index = np.argmin(np.abs(fpr_all - self.target_value))
+        elif self.target_criterion == "tpr":
+            index = np.argmin(np.abs(tpr_all - self.target_value))
+        elif self.target_criterion == "accuracy":
+            # Assuming classes are balanced, we have that:
+            #  Accuracy(t) = 1/2 (TPR + TNR) = 1/2 (TPR + 1 - FPR).
+            index = np.argmax(tpr_all - fpr_all)
+        self._threshold = thresholds[index]
+
+    def attack(self, datasets: list[Dataset]):
+        """
+        Make a prediction for each dataset.
+
+        This computes attack_score for each dataset, then decides that the
+        target user is in the training dataset if and only if the score is
+        higher than self._threshold.
+
+        Parameters
+        ----------
+        datasets: a list of synthetic datasets.
+
+        Returns
+        -------
+        predictions: np.array of booleans.
+
+        """
+        if self._threshold is None:
+            raise Exception("Attack has not been trained (threshold is None).")
+        scores = self.attack_score(datasets)
+        return scores >= self._threshold
+
+    # Implement this if needed.
+    def _train_attack_score(
+        self, threat_model: LabelInferenceThreatModel, num_samples: int = 100, **kwargs
+    ):
+        """
+        Train the attack score function (optional). By default, this does nothing.
+
+        Interface to implement
+        ----------------------
+        threat_model: LabelInferenceThreatModel
+            The threat model from which to generate training samples.
+        num_samples: int (default 100)
+            Number of samples to generate to train the attack score.
+        optional keyword arguments: passed from .train(**kwargs).
+
+        """
+        pass

--- a/prive/attacks/base_classes.py
+++ b/prive/attacks/base_classes.py
@@ -76,6 +76,7 @@ import numpy as np
 from sklearn.metrics import roc_curve
 
 
+# TODO: extend to multi-class labels. Currently assumes binary labels.
 class TrainableThresholdAttack(Attack):
     """
     Generic class to represent attacks that rely on a score, combined with a

--- a/prive/attacks/base_classes.py
+++ b/prive/attacks/base_classes.py
@@ -136,6 +136,7 @@ class TrainableThresholdAttack(Attack):
         num_samples: int (default, 100).
             Number of training samples to generate to select the threshold.
         (optionally), additional keyword arguments, passed to _train_attack_score.
+
         """
         # First, optionally train the score.
         assert isinstance(

--- a/prive/attacks/closest_distance.py
+++ b/prive/attacks/closest_distance.py
@@ -15,10 +15,13 @@ from sklearn.metrics import roc_curve
 
 from .base_classes import Attack, TrainableThresholdAttack
 from .distances import DistanceMetric, HammingDistance
-from ..threat_models import TargetedMIA
+
+from ..datasets import TabularDataset
+from ..threat_models import TargetedMIA, TargetedAIA
 
 
-class ClosestDistanceAttack(TrainableThresholdAttack):
+# TODO: k-nearest neighbours?
+class ClosestDistanceMIA(TrainableThresholdAttack):
     """
     Attack that looks for the closest record to a given target in the
     synthetic data to determine whether the target was in the
@@ -78,6 +81,186 @@ class ClosestDistanceAttack(TrainableThresholdAttack):
             # This is because larger scores are associated with higher probability
             # of membership, whereas distances do the opposite.
             scores.append(-np.min(distances))
+        return np.array(scores)
+
+    @property
+    def label(self):
+        return self._label
+
+
+class ClosestDistanceAIA(ClosestDistanceMIA):
+    """
+    Attack that finds the closest-record to the target record, and uses the
+    value of the sensitive attribute of that closest-record as answer to the
+    attribute-inference attack.
+
+    This attack is a bit more flexible: for each value v, it returns a score
+    equal to  - distance(r(v), D) / sum_v' distance(r(v'), D), where r(v) is
+    the target record with v as value for its sensitive attribute.
+
+    This is a TrainableThresholdAttack, and thus is able to automatically
+    select the threshold for .attack from .attack_score. To set the behaviour
+    to be "choose v minimising distance(r(v), D)", set:
+    criterion = ("threshold", -0.5) in the constructor of this object.
+
+    """
+
+    # Same __init__ as ClosestDistanceMIA.
+
+    def attack_score(self, datasets: list[Dataset]):
+        """
+        Compute the decision score for this attack.
+
+        The target score is the minimal distance between the target record with
+        a given value v for the sensitive attribute and records in the
+        synthetic dataset, weighted such that the sum of scores is 1 for each
+        dataset. If the distance is 0 for all values, this returns 1/num_values
+        for each value.
+        
+        Parameters
+        ----------
+        datasets: a list of synthetic datasets.
+
+        Returns
+        -------
+        scores: array of size len(datasets) or len(datasets) x k
+            If the number of possible values (threat_model.attribute_values) is
+            two, then the scores array is 1-dimensional, and each entry
+            contains the score for the second ("positive") value.
+            Otherwise, this returns a score per value, and k is the number of
+            possible values (k = len(self.threat_model.attribute_values).
+
+        """
+        # Modify the records to have different target values.
+        modified_records = {}
+        for value in self.threat_model.attribute_values:
+            r = self.threat_model.target_record.copy()
+            r.set_value(self.threat_model.sensitive_attribute, value)
+            modified_records[value] = r
+        # For each dataset, compute the min distance from the modified record
+        # to records in the synthetic datasets.
+        # (This is somewhat of a trick to use general distance metrics).
+        scores = []
+        for dataset in datasets:
+            # Compute distance(r(v), D) for each record.
+            distances = np.array(
+                [
+                    self.distance(modified_records[v], dataset)[0].min()
+                    for v in self.threat_model.attribute_values
+                ]
+            )
+            # Compute the relative scores.
+            if distances.sum() > 1e-16:
+                s = distances / distances.sum()
+            else:
+                # If all distances are 0, use uninformative scores.
+                s = np.full(distances.shape, 1 / len(distances))
+            # For binary choices, only return the second element (score for 1).
+            if len(s) == 2:
+                s = s[1]
+            scores.append(- s)
+        return np.array(scores)
+
+
+class LocalNeighbourhoodAttack(TrainableThresholdAttack):
+    """
+    Attack that makes a decision based on records similar to the target record,
+    specifically all records within a sphere of a given radius, for a specific
+    choice of distance.
+
+    For membership inference attacks, the score is the fraction of all records
+    that are within distance `radius` of the target record.
+
+    For attribute inference attacks, the score is the fraction of all records
+    within the sphere which have a given value for the sensitive attribute.
+
+    """
+
+    def __init__(
+        self,
+        distance: DistanceMetric = HammingDistance(),
+        radius: float = 1,
+        criterion="accuracy",
+        label: str = None,
+    ):
+        """
+        Create the attack with chosen parameters.
+
+        Parameters
+        ----------
+        distance: DistanceMetric
+            Distance to use between records for the attack.
+        radius: float
+        criterion: tuple
+            Criterion to select the threshold (see TrainableThresholdAttack for details).
+        label (optional): name of this attack, for reporting.
+        """
+        TrainableThresholdAttack.__init__(self, criterion)
+        self.distance = distance
+        self.radius = radius
+        self._label = (
+            label or f"LocalNeighbourhood({distance.label}, {radius}, {criterion})"
+        )
+
+    def attack_score(self, datasets: list[Dataset]):
+        """
+        Compute the decision score for this attack.
+
+        Parameters
+        ----------
+        datasets: a list of synthetic datasets.
+
+        Returns
+        -------
+        scores: a np.array of scores.
+            For attribute inference attacks, if the number k of possible values
+            is > 2, this is of size len(datasets) x k, where entry (i,j) is for
+            dataset i and value j. Otherwise, this is an array of len(dataset)
+            scores, with a score per dataset.
+
+        """
+        # First, check that the attack model is compatible.
+        if isinstance(self.threat_model, TargetedMIA):
+            mia = True
+        elif isinstance(self.threat_model, TargetedAIA):
+            mia = False
+        else:
+            raise Exception("Unsupported threat model.")
+        # Compute local spheres and decision based on that.
+        scores = []
+        for dataset in datasets:
+            # Compute the sphere around the record.
+            distances = self.distance(self.threat_model.target_record, dataset)[0]
+            in_sphere = distances <= self.radius
+            # Make a decision based on this.
+            if mia:
+                # MIA: return the fraction of all records that are in sphere.
+                scores.append(np.mean(in_sphere))
+            else:
+                # AIA: compute a histogram of the attribute values.
+                if isinstance(dataset, TabularDataset):
+                    attr_values = self.threat_model.attribute_values
+                    if in_sphere.sum() == 0:
+                        # If there are no entries, make the score be 1/k
+                        k = len(attr_values)
+                        s = np.full((k,), 1 / k)
+                    else:
+                        s = np.zeros((len(attr_values),))
+                        # We here use the internal representation of the dataset
+                        # as a Pandas DataFrame.
+                        values_in_sphere = dataset.data[
+                            self.threat_model.sensitive_attribute
+                        ].values[in_sphere]
+                        # Compute a score for each value.
+                        for i, v in enumerate(attr_values):
+                            s[i] = np.mean(values_in_sphere == v)
+                    # If there are only two values, return the score for the
+                    # second ("positive") value.
+                    if len(attr_values) == 2:
+                        s = s[1]
+                    scores.append(s)
+                else:
+                    raise Exception("Unsupported dataset type.")
         return np.array(scores)
 
     @property

--- a/prive/attacks/closest_distance.py
+++ b/prive/attacks/closest_distance.py
@@ -1,11 +1,15 @@
-"""Closest-distance attacks """
+"""Closest-distance attacks.
+
+These attacks use the local neighbourhood of real records in the synthetic data
+to make inferences about those real records.
+
+"""
 
 # Imports for type annotations.
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from ..datasets import Dataset, DataDescription
     from ..threat_models import ThreatModel
 
@@ -158,7 +162,7 @@ class ClosestDistanceAIA(ClosestDistanceMIA):
             # For binary choices, only return the second element (score for 1).
             if len(s) == 2:
                 s = s[1]
-            scores.append(- s)
+            scores.append(-s)
         return np.array(scores)
 
 

--- a/prive/attacks/closest_distance.py
+++ b/prive/attacks/closest_distance.py
@@ -3,32 +3,38 @@
 # Imports for type annotations.
 from __future__ import annotations
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from ..datasets import Dataset, DataDescription
-    from ..threat_models import ThreatModel # for typing
+    from ..threat_models import ThreatModel
 
 import numpy as np
 from sklearn.metrics import roc_curve
 
-from .base_classes import Attack
+from .base_classes import Attack, TrainableThresholdAttack
+from .distances import DistanceMetric
 from ..threat_models import TargetedMIA
 
 
-class ClosestDistanceAttack(Attack):
-    """Attack that looks for the closest record to a given target in the
-        synthetic data to determine whether the target was in the
-        training dataset.
+class ClosestDistanceAttack(TrainableThresholdAttack):
+    """
+    Attack that looks for the closest record to a given target in the
+    synthetic data to determine whether the target was in the
+    training dataset.
 
-       This attack predicts that a target record is in the training dataset
-        iff:  min_{x in synth_data} distance(x, target) <= threshold.
-       The threshold can either be specified, or selected automatically.
+    This attack predicts that a target record is in the training dataset
+     iff:  min_{x in synth_data} distance(x, target) <= threshold.
+    The threshold can either be specified, or selected automatically.
 
     """
 
-    def __init__(self, distance_function: Callable[[Dataset,Dataset], float] = None,
-                 threshold: float = None, fpr: float = None, tpr: float = None,
-                 metric_name='default'):
+    def __init__(
+        self,
+        distance_function: DistanceMetric = None,
+        criterion: dict = "accuracy",
+        metric_name="default",
+    ):
         """
         Create the attack with chosen parameters.
 
@@ -36,66 +42,16 @@ class ClosestDistanceAttack(Attack):
         ----------
         distance_function (callable): maps (record1, record2) to a positive
             float. If left None (default), this is self._default_distance.
-        threshold: decision threshold for the classifier. If lest None (default),
-            the threshold is learned from training data.
-        fpr/tpr: the target false/true positive rate for the threshold selection.
+        criterion: tuple
+            Criterion to select the threshold (see TrainableThresholdAttack for details)
         metric_name (optional): name of the distance metric used.
 
         Exactly one of threshold, fpr or tpr must be not None.
 
         """
+        TrainableThresholdAttack.__init__(self, criterion)
         self.distance_function = distance_function or self._default_distance
-        # Check that at least one of threshold, tpr and fpr is set.
-        self.threshold = threshold
-        self.fpr, self.tpr = fpr, tpr
-        assert ((fpr is None) + (tpr is None) + (threshold is None)) == 2,\
-            'Exactly one of threshold, fpr or tpr must be specified.'
-
-        self.trained = False
-
-        self.__name__ = f'ClosestDistance({metric_name}, '
-        if fpr is not None:
-            self.__name__ += f'fpr={self.fpr:.2f})'
-        elif tpr is not None:
-            self.__name__ += f'tpr={self.tpr:.2f})'
-        else:
-            self.__name__ += f'threshold={self.threshold})'
-
-
-    def train(self, threat_model: TargetedMIA, num_samples: int = 5):
-        """
-        Train the attack for a specific target.
-
-        Select a target for the attack, and -- if needed -- use samples
-         (synthetic datasets) to select a threshold that results in
-         approximately the target fpr/tpr.
-
-        Parameters
-        ----------
-        threat_model: the threat model of this attack, must be a TargetedMIA.
-        num_samples: number of training  datasets to generate (default: 100).
-
-        """
-        assert isinstance(threat_model, TargetedMIA), \
-             "Incompatible attack model: needs targeted MIA."
-        self.threat_model = threat_model
-        self.target_record = self.threat_model.target_record
-        if self.threshold is not None:
-            self.trained = True
-            return  # No training required.
-        # If the threshold is not specified, train to get the desired tpr or fpr.
-        synthetic_datasets, labels = self.threat_model.generate_training_samples(num_samples)
-        # Compute the roc curve with - threshold, since the decision we use is
-        #  score <= threshold, but roc_curve uses score >= threshold.
-        fpr_all, tpr_all, thresholds = roc_curve(labels, - self.attack_score(synthetic_datasets))
-        # Select the threshold such that the fpr (or tpr) is closest to target.
-        if self.fpr is not None:
-            index = np.argmin(np.abs(fpr_all - self.fpr))
-        else:
-            index = np.argmin(np.abs(tpr_all - self.tpr))
-        self.threshold = - thresholds[index]
-        self.trained = True
-
+        self.__name__ = f"ClosestDistance({metric_name}, {criterion})"
 
     def attack_score(self, datasets: list[Dataset]):
         """
@@ -113,37 +69,16 @@ class ClosestDistanceAttack(Attack):
         scores: array of (nonnegative) record distances.
 
         """
+        target_record = self.threat_model.target_record
         scores = []
         for ds in datasets:
             # Use the __iter__ function of Dataset to iterate over records.
-            distances = [self.distance_function(record, self.target_record) for record in ds]
-            scores.append(np.min(distances))
+            distances = [self.distance_function(record, target_record) for record in ds]
+            # The attack score is the NEGATIVE min distance to the target record.
+            # This is because larger scores are associated with higher probability
+            # of membership, whereas distances do the opposite.
+            scores.append(-np.min(distances))
         return np.array(scores)
-
-
-    def attack(self, datasets: list[Dataset]):
-        """
-        Make a prediction of membership for the record in each dataset.
-
-        This computes attack_score for each dataset, then decides that the
-        target user is in the training dataset if and only if the closest
-        record in the synthetic data is at a distance <= self.threshold to
-        the target dataset.
-
-        Parameters
-        ----------
-        datasets: a list of synthetic datasets.
-
-        Returns
-        -------
-        predictions: array of booleans.
-
-        """
-        if not self.trained:
-            raise Exception('Please train this attack.')
-        attack_scores = self.attack_score(datasets)
-        return attack_scores <= self.threshold
-
 
     def _default_distance(self, x: Dataset, y: Dataset):
         """

--- a/prive/attacks/distances.py
+++ b/prive/attacks/distances.py
@@ -1,0 +1,31 @@
+"""
+Distance metrics for closest-distance attacks.
+
+Distances are callable objects that return an array of real number for pairs of
+datasets (either records, or datasets of same lengths). We here implement a
+range of simple distances, and easy methods to combine them.
+
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..datasets import Dataset, DataDescription
+
+from abc import ABC, abstractmethod
+
+
+class DistanceMetric:
+    """"""
+
+    @abstractmethod
+    def __call__(self, x: Dataset, y: Dataset):
+        return float("inf")
+
+    # Interface to easily combine distance metrics.
+    def __sum__(self, d: DistanceMetric):
+        pass
+
+    def __prod__(self, factor: float):
+        pass

--- a/prive/attacks/distances.py
+++ b/prive/attacks/distances.py
@@ -14,18 +14,156 @@ if TYPE_CHECKING:
     from ..datasets import Dataset, DataDescription
 
 from abc import ABC, abstractmethod
+from ..datasets import TabularDataset
+import numpy as np
 
 
 class DistanceMetric:
-    """"""
+    """
+    Distance metric between datasets. This is a callable of two datasets that
+    returns an array of pairwise distances, with a label for attack labelling.
+
+    """
 
     @abstractmethod
     def __call__(self, x: Dataset, y: Dataset):
-        return float("inf")
+        """
+        Compute the distance between all records in x with records in y.
 
-    # Interface to easily combine distance metrics.
-    def __sum__(self, d: DistanceMetric):
-        pass
+        Parameters
+        ----------
+        x, y: two Dataset of same description.
 
-    def __prod__(self, factor: float):
-        pass
+        Returns
+        -------
+        distances: np.array of size len(x) x len(y).
+
+        """
+        return np.full((len(x), len(y)), np.inf)
+
+    ## Interface to easily combine distance metrics.
+    # Sum of distances.
+    def __add__(self, d: DistanceMetric):
+        return SumOfDistances([self, d])
+
+    # Multiply this distance metric by scaling factor.
+    def __mul__(self, factor: float):
+        return ScaledDistance(self, factor)
+
+    def __rmul__(self, factor: float):
+        return self.__mul__(factor)
+
+    @property
+    def label(self):
+        return self._label
+
+
+class SumOfDistances(DistanceMetric):
+    """(internal) class for __sum__."""
+
+    def __init__(self, distances: list[DistanceMetric]):
+        self.distances = distances
+        self._label = "+".join([d.label for d in self.distances])
+
+    def __call__(self, x: Dataset, y: Dataset):
+        dists = [d(x, y) for d in self.distances]
+        return sum(dists[1:], start=dists[0])
+
+
+class ScaledDistance(DistanceMetric):
+    """(internal) class for __prod__."""
+
+    def __init__(self, distance: DistanceMetric, factor: float):
+        self.distance = distance
+        self.factor = factor
+        self._label = f"{factor}*{distance.label}"
+
+    def __call__(self, x: Dataset, y: Dataset):
+        return self.factor * self.distance(x, y)
+
+
+## We implement a few common distances.
+
+
+class HammingDistance(DistanceMetric):
+    """
+    Hamming distance ("L_0"): counts the number of attributes that are
+    identical between two records. While this is mainly for categorical
+    attributes, it also works with continuous values.
+
+    """
+
+    def __init__(self, columns: list[str] = None):
+        """
+        Parameters
+        ----------
+        columns: list of column names, optional (None)
+            List of the columns on which to compute the distance. If this is
+            not provided, all columns are used. Only for tabular datasets.
+
+        """
+        self.columns = columns
+        self._label = "Hamming"
+        if columns:
+            self._label += "(" + ", ".join(columns) + ")"
+
+    def __call__(self, x: Dataset, y: Dataset):
+        # Check that the datasets have the same description.
+        assert (
+            x.description == y.description
+        ), "Input datasets must have same description."
+        # The distance is implemented differently for different data types.
+        if isinstance(x, TabularDataset):
+            dists = np.zeros((len(x), len(y)))
+            for i, (_, row) in enumerate(x.data.iterrows()):
+                dists[i] = (y.data != row).sum(axis=1).values
+            return dists
+        else:
+            raise Exception("Unsupported dataset type.")
+
+
+class LpDistance(DistanceMetric):
+    """
+    L_p distance between two datasets (typically, tabular datasets).
+    This 1-hot encodes categorical attributes.
+
+    """
+
+    def __init__(self, p: float = 2, weights: np.array = None):
+        """
+        Parameters
+        ----------
+        p: float
+            Order of the distance (default 2, Euclidean distance). p must be
+            a positive number.
+        weights: real-valued numpy array
+            Weighting to apply to individual entries in the 1-hot encoded
+            dataset. The distance between records x and y (of length k) is
+            computed as (sum_i weights_i * abs(x_i - y_i)^p )^(1/p).
+
+        Use the weights to restrict this distance to a specific subset of
+        variables (e.g., to exclude 1-hot encoded columns).
+
+        """
+        self.p = p
+        assert self.p > 0, "Order p must be positive."
+        self.weights = weights
+        self._label = f"L_{p}"
+
+    def __call__(self, x: Dataset, y: Dataset):
+        assert (
+            x.description == y.description
+        ), "Input datasets must have same description."
+        if isinstance(x, TabularDataset):
+            # 1-hot encode both datasets.
+            x_1hot = x.as_numeric
+            y_1hot = y.as_numeric
+            # Set uniform weights (1) if none are provided.
+            weights = self.weights if self.weights is not None else np.ones(x_1hot.shape[1])
+            dists = np.zeros((len(x), len(y)))
+            for i in range(x_1hot.shape[0]):
+                # The distance is defined as (sum_i weights_i * abs(x_i - y_i)^p)^(1/p).
+                dists[i] = (np.abs(y_1hot - x_1hot[i,:])**self.p).dot(weights)**(1/self.p)
+            return dists
+        else:
+            raise Exception("Unsupported dataset type.")

--- a/prive/attacks/synthinference.py
+++ b/prive/attacks/synthinference.py
@@ -1,0 +1,174 @@
+"""Attacks based on inference models trained on synthetic data.
+
+This groups attacks that follow the following approximate structure:
+ 1. Train a statistical model on the synthetic data.
+ 2. Use this model to infer something about the real data.
+
+The second step often involves applying the model to a target record.
+
+"""
+
+# Imports for type annotations.
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..datasets import Dataset
+    from ..threat_models import ThreatModel
+    from sklearn.base import ClassifierMixin
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from .base_classes import Attack, TrainableThresholdAttack
+from ..threat_models import TargetedMIA, TargetedAIA
+from ..datasets import TabularDataset
+
+
+class DensityEstimator(ABC):
+    """
+    Density estimator for records in a dataset.
+
+    """
+
+    @abstractmethod
+    def fit(self, dataset: Dataset):
+        pass
+
+    @abstractmethod
+    def score(self, dataset: Dataset):
+        pass
+
+    @property
+    def label(self):
+        return self._label
+
+
+class sklearnDensityEstimator(DensityEstimator):
+    """
+    Extends DensityEstimator to run a sklearn model on a 1-hot encoding of datasets.
+    This is mostly intended as an internal wrapper for Tabular datasets.
+
+    """
+
+    def __init__(self, model, label=None):
+        self.model = model
+        self._label = label or str(model)
+
+    def fit(self, dataset: Dataset):
+        self._data_description = dataset.description
+        self.model.fit(dataset.as_numeric)
+
+    def score(self, dataset: Dataset):
+        assert (
+            dataset.description == self._data_description
+        ), "Incompatible data description!"
+        return self.model.score_samples(dataset.as_numeric)
+
+
+class ProbabilityEstimationAttack(TrainableThresholdAttack):
+    """
+    Membership Inference Attack that first estimates a statistical model p_x
+    of the distribution of records in the *synthetic* data, and then uses
+    p_x(target_record) as score. The intuition is that the distribution of the
+    synthetic data, which is defined by the generator trained on the real data,
+    is more likely to be high for records in the real data. This works best on
+    overfitted models.
+
+    """
+
+    def __init__(
+        self, estimator: DensityEstimator, criterion: tuple, label: str = None
+    ):
+        """
+        Create an inference-on-synthetic attack.
+
+        Parameters
+        ----------
+        estimator: DensityEstimator
+            The estimator, as a DensityEstimator object with .fit and .score.
+            If an object of another type is passed, this object is assumed to
+            be a sklearn model, and is fed into sklearnDensityEstimator.
+        criterion: str or tuple
+            How to select the threshold (see TrainableThresholdAttack).
+        label: str (optional)
+            String to represent this attack.
+
+        """
+        TrainableThresholdAttack.__init__(self, criterion)
+        if not isinstance(estimator, DensityEstimator):
+            estimator = sklearnDensityEstimator(estimator)
+        self.estimator = estimator
+        self._label = label or f"ProbabilityEstimation({estimator.label})"
+
+    def attack_score(self, datasets: list[Dataset]):
+        """
+        Perform the attack on each dataset in a list, but return a confidence
+        score (specifically for classification tasks).
+
+        """
+        assert isinstance(
+            self.threat_model, TargetedMIA
+        ), "This attack can only applied to targeted MIAs."
+        # Treat each dataset individually.
+        scores = []
+        for dataset in datasets:
+            self.estimator.fit(dataset)
+            scores.append(self.estimator.score(self.threat_model.target_record)[0])
+        return np.array(scores)
+
+    @property
+    def label(self):
+        return self._label
+
+
+class SyntheticPredictorAttack(TrainableThresholdAttack):
+    """
+    Attribute Inference Attack that first trains a classifier C on the
+    synthetic data to predict the sensitive value v of a record x, then uses
+    C(target_record) as prediction for the target record.
+
+    This is a common baseline, linked to CAP (Correct Attribution Probability),
+    although whether it constitutes a privacy violation is controversial, since
+    correlations in the data could reveal the sensitive attribute even if the
+    user does not contribute their data. PrivE circumvents this issue by
+    randomising the sensitive attribute independently from all others. As such,
+    this attack mostly aims at detecting overfitted models.
+
+    This attack is implemented exclusively for tabular data.
+
+    """
+
+    def __init__(self, estimator: ClassifierMixin, criterion: tuple, label=None):
+        TrainableThresholdAttack.__init__(self, criterion)
+        self.estimator = estimator
+        self._label = label or f"SyntheticPredictor({estimator})"
+
+    def attack_score(self, datasets: list[Dataset]):
+        assert isinstance(
+            self.threat_model, TargetedAIA
+        ), "This attack can only be applied to targeted AIAs."
+        scores = []
+        target_record_x = self.threat_model.target_record.view(
+            exclude_columns=[self.threat_model.sensitive_attribute]
+        )
+        for dataset in datasets:
+            assert isinstance(
+                dataset, TabularDataset
+            ), "This attack can only be applied to TabularDatasets."
+            # Train a classifier to predict the sensitive attribute from the rest.
+            X = dataset.view(exclude_columns=[self.threat_model.sensitive_attribute])
+            y = dataset.view(columns=[self.threat_model.sensitive_attribute])
+            self.estimator.fit(X.as_numeric, y.data.values.ravel())
+            # Apply this model to the target record.
+            score = self.estimator.predict_proba(target_record_x.as_numeric)[0]
+            # If there are only two classes, set the second label as positive.
+            if len(score) == 2:
+                score = score[1]
+            scores.append(score)
+        return np.array(scores)
+
+    @property
+    def label(self):
+        return self._label

--- a/prive/attacks/utils.py
+++ b/prive/attacks/utils.py
@@ -1,5 +1,5 @@
 from .groundhog import GroundhogAttack
-from .closest_distance import ClosestDistanceAttack
+from .closest_distance import ClosestDistanceMIA
 
 from .set_classifiers import FeatureBasedSetClassifier, NaiveSetFeature, HistSetFeature
 
@@ -38,7 +38,7 @@ def load_attack(name, params, dataset):
         fpr = params.get("fpr", None)
         tpr = params.get("tpr", None)
         convert = lambda s: None if s in None else float(s)
-        attack = ClosestDistanceAttack(
+        attack = ClosestDistanceMIA(
             fpr=convert(fpr), tpr=convert(tpr), threshold=convert(threshold),
         )
 

--- a/prive/datasets/data_description.py
+++ b/prive/datasets/data_description.py
@@ -19,6 +19,13 @@ class DataDescription:
         self.schema = schema
         self._label = label or "Unnamed dataset"
 
+    def view(self, columns):
+        """
+        Returns the same DataDescription restricted to a subset of columns.
+
+        """
+        return DataDescription([c for c in self.schema if (c['name'] in columns)], self.label)
+
     @property
     def num_features(self):
         """
@@ -26,6 +33,15 @@ class DataDescription:
 
         """
         return len(self.schema)
+
+    @property
+    def columns(self):
+        """
+        tuple: name of all columns, in order.
+
+        """
+        return tuple([column['name'] for column in self.schema])
+    
 
     @property
     def encoded_dim(self):

--- a/prive/datasets/dataset.py
+++ b/prive/datasets/dataset.py
@@ -497,6 +497,39 @@ class TabularDataset(Dataset):
         """
         return TabularDataset(self.data.copy(), self.description)
 
+    def view(self, columns = None, exclude_columns = None):
+        """
+        Create a TabularDataset object that contains a subset of the columns of
+        this TabularDataset. The resulting object only has a copy of the data,
+        and can thus be modified without affecting the original data.
+
+        Parameters
+        ----------
+        Exactly one of `columns` and `exclude_columns` must be defined.
+
+        columns: list, or None
+            The columns to include in the view.
+        exclude_columns: list, or None
+            The columns to exclude from the view, with all other columns included.
+
+        Returns
+        -------
+        TabularDataset
+            A subset of this data, restricted to some columns.
+
+        """
+        assert (
+            columns is not None or exclude_columns is not None
+        ), "Empty view: specify either columns or exclude_columns."
+        assert (
+            columns is None or exclude_columns is None
+        ), "Overspecified view: only one of columns and exclude_columns can be given."
+
+        if exclude_columns is not None:
+            columns = [c for c in self.description.columns if c not in exclude_columns]
+
+        return TabularDataset(self.data[columns], self.description.view(columns))
+
     @property
     def as_numeric(self):
         """

--- a/prive/datasets/dataset.py
+++ b/prive/datasets/dataset.py
@@ -6,9 +6,9 @@ import io
 import numpy as np
 import pandas as pd
 
-
 from prive.datasets.data_description import DataDescription
 from .utils import encode_data, index_split, get_dtype
+
 
 # Helper function for parsing file-like objects
 def _parse_csv(fp, schema, label=None):

--- a/prive/run_groundhog.py
+++ b/prive/run_groundhog.py
@@ -6,7 +6,7 @@ import numpy as np
 from prive.attacks.set_classifiers import LRClassifier, RFClassifier, \
     SetReprClassifier, NaiveRep
 from prive.threat_models.mia import TargetedAuxiliaryDataMIA
-from prive.attacks import Groundhog, ClosestDistanceAttack
+from prive.attacks import Groundhog, ClosestDistanceMIA
 from prive.datasets import TabularDataset, TabularRecord
 
 from prive.generators import ReturnRaw
@@ -55,7 +55,7 @@ test_labels, predictions = threat_model.test(attack, num_test_samples,
                                              replace_target=True, save_datasets=True)
 
 # We can also define a second attack, which will reuse memoized datasets.
-#attack_cd = ClosestDistanceAttack(threat_model)
+#attack_cd = ClosestDistanceMIA(threat_model)
 #attack_cd.train(num_samples = 100)
 #test_labels_cd, predictions_cd = threat_model.test(attack_cd, num_test_samples)
 

--- a/prive/tests/test_attacks.py
+++ b/prive/tests/test_attacks.py
@@ -18,7 +18,7 @@ from prive.generators import Raw
 
 # The classes being tested.
 from prive.attacks import (
-    ClosestDistanceAttack,
+    ClosestDistanceMIA,
     GroundhogAttack,
     NaiveSetFeature,
     HistSetFeature,
@@ -71,7 +71,7 @@ class TestClosestDistance(TestCase):
 
         # Take a record that is not in the dataset (distance 1/2).
         mia = self._make_mia(0, 0)
-        attack = ClosestDistanceAttack(criterion=("threshold", -0.3))
+        attack = ClosestDistanceMIA(criterion=("threshold", -0.3))
         attack.train(mia)
         # Check that the training worked as intended.
         self.assertEqual(attack._threshold, -0.3)
@@ -85,7 +85,7 @@ class TestClosestDistance(TestCase):
         self.assertEqual(attack.attack([self.dataset])[0], False)
 
         # Perform the attack for a user *in* the dataset.
-        attack = ClosestDistanceAttack(criterion=("threshold", -0.3))
+        attack = ClosestDistanceMIA(criterion=("threshold", -0.3))
         attack.train(self._make_mia(0, 1))
         print("attack")
         self.assertEqual(attack.attack([self.dataset])[0], True)
@@ -101,9 +101,9 @@ class TestClosestDistance(TestCase):
             BlackBoxKnowledge(generator=Raw(), num_synthetic_records=2),
             replace_target=True,
         )
-        attack_tpr = ClosestDistanceAttack(criterion=("tpr", 0.1))
+        attack_tpr = ClosestDistanceMIA(criterion=("tpr", 0.1))
         attack_tpr.train(mia)
-        attack_fpr = ClosestDistanceAttack(criterion=("fpr", 0.1))
+        attack_fpr = ClosestDistanceMIA(criterion=("fpr", 0.1))
         attack_fpr.train(mia)
 
     def test_distances(self):

--- a/prive/tests/test_attacks.py
+++ b/prive/tests/test_attacks.py
@@ -40,6 +40,8 @@ dummy_data_description = DataDescription(
 dummy_data = pd.DataFrame([(0, 1), (0, 2), (3, 4), (3, 5)], columns=["a", "b"])
 
 
+## Test for closest-distance attack.
+
 class TestClosestDistance(TestCase):
     """Test the closest-distance attack."""
 
@@ -66,21 +68,21 @@ class TestClosestDistance(TestCase):
 
         # Take a record that is not in the dataset (distance 1/2).
         mia = self._make_mia(0, 0)
-        attack = ClosestDistanceAttack(threshold=0.3)
+        attack = ClosestDistanceAttack(criterion=('threshold', 0.3))
         attack.train(mia)
         # Check that the training worked as intended.
-        self.assertEqual(attack.trained, True)
+        self.assertEqual(attack._threshold, 0.3)
         # Check that the score is working as intended.
         scores = attack.attack_score([rec for rec in self.dataset])
         self.assertEqual(len(scores), len(self.dataset))
         for score, distance in zip(scores, [0.5, 0.5, 1, 1]):
-            self.assertEqual(score, distance)
+            self.assertEqual(score, -distance)
         # Assert that the total score and decisions are ok.
-        self.assertEqual(attack.attack_score([self.dataset])[0], 0.5)
+        self.assertEqual(attack.attack_score([self.dataset])[0], -0.5)
         self.assertEqual(attack.attack([self.dataset])[0], False)
 
         # Perform the attack for a user *in* the dataset.
-        attack = ClosestDistanceAttack(threshold=0.3)
+        attack = ClosestDistanceAttack(criterion=('threshold', -0.3))
         attack.train(self._make_mia(0, 1))
         self.assertEqual(attack.attack([self.dataset])[0], True)
 
@@ -95,14 +97,13 @@ class TestClosestDistance(TestCase):
             BlackBoxKnowledge(generator=Raw(), num_synthetic_records=2),
             replace_target=True,
         )
-        attack_tpr = ClosestDistanceAttack(tpr=0.1)
+        attack_tpr = ClosestDistanceAttack(criterion=('tpr', 0.1))
         attack_tpr.train(mia)
-        attack_fpr = ClosestDistanceAttack(fpr=0.1)
+        attack_fpr = ClosestDistanceAttack(criterion=('fpr', 0.1))
         attack_fpr.train(mia)
 
 
 ## Test for features.
-
 
 class TestSetFeatures(TestCase):
     """Test whether the set features defined for Groundhog are implemented correctly."""
@@ -232,7 +233,6 @@ class TestSetFeatures(TestCase):
 
 
 ## Test for the Groundhog attack.
-
 
 class TestGroundHog:
     """Test whether the groundhog attack (Stadler et al.) works."""

--- a/prive/tests/test_threat_models.py
+++ b/prive/tests/test_threat_models.py
@@ -54,7 +54,7 @@ class TestMIA(TestCase):
         # Check that we generate the correct number of samples.
         num_samples = 100
         datasets, labels = mia.generate_training_samples(num_samples)
-        self.assertEqual(len(datasets), num_samples * (1 + generate_pairs))
+        self.assertEqual(len(datasets), num_samples)
         self.assertEqual(len(datasets), len(labels))
         # We here use RAW as a generator, so the datasets generated are the
         # training datasets directly. We can thus check target membership on

--- a/prive/threat_models/aia.py
+++ b/prive/threat_models/aia.py
@@ -77,13 +77,11 @@ class AIALabeller(AttackerKnowledgeWithLabel):
         # Generate the datasets from the attacker knowledge.
         datasets = self.attacker_knowledge.generate_datasets(num_samples, training)
         # Sample target attributes iid.
-        labels = list(
-            np.random.choice(
+        labels = np.random.choice(
                 self.attribute_values,
                 size=(num_samples,),
                 replace=True,
                 p=self.distribution,
-            )
         )
         # Modify the record with all possible values, and save.
         modified_records = {}
@@ -91,13 +89,17 @@ class AIALabeller(AttackerKnowledgeWithLabel):
             r = self.target_record.copy()
             r.set_value(self.sensitive_attribute, value)
             modified_records[value] = r
+        # Encode the labels as integers (0, ..., num_values-1).
+        enc_labels = np.zeros(labels.shape, dtype=int)
+        for i, v in enumerate(self.attribute_values):
+            enc_labels[labels == v] = i
         # Replace the records in each dataset, and return the labels.
         return (
             [
                 ds.replace(modified_records[v], in_place=False)
                 for ds, v in zip(datasets, labels)
             ],
-            labels,
+            list(enc_labels),
         )
 
 

--- a/prive/threat_models/attacker_knowledge.py
+++ b/prive/threat_models/attacker_knowledge.py
@@ -266,7 +266,7 @@ class BlackBoxKnowledge(AttackerKnowledgeOnGenerator):
 # where the attacker aims to infer the "label" of the private dataset. The
 # label is defined by the attacker's knowledge being AttackerKnowledgeWithLabel.
 
-
+# TODO: add output class.
 class LabelInferenceThreatModel(TrainableThreatModel):
     def __init__(
         self,

--- a/prive/threat_models/attacker_knowledge.py
+++ b/prive/threat_models/attacker_knowledge.py
@@ -319,19 +319,21 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         training: bool (default, True)
             whether to generate samples from the training or test distribution.
         ignore_memory: bool, default False
-            Whether to use the memoised datasets, or ignore them.
+            Whether to ignore the memoised datasets.
 
         """
         # Retrieve memoized samples (if needed).
-        if not ignore_memory:
+        use_memory = (not ignore_memory) and self.memorise_datasets
+        if use_memory:
+            mem_datasets, mem_labels = self._memory[training]
+            if num_samples <= len(mem_datasets):
+                # No samples are needed! Return what is in memory:
+                return mem_datasets[:num_samples], mem_labels[:num_samples]
+            # Decrease the number of samples (= number of samples to generate).
+            num_samples -= len(mem_datasets)
+        else:
             mem_datasets = []
             mem_labels = []
-        else:
-            mem_datasets, mem_labels = self._memory[training]
-            num_samples -= len(mem_datasets)
-            # No samples are needed! Return what is in memory:
-            if num_samples <= 0:
-                return mem_datasets[:num_samples], mem_labels[:num_samples]
         # Generate sample: first, produce the original datasets with labels.
         training_datasets, gen_labels = self.atk_know_data.generate_datasets_with_label(
             num_samples, training=training
@@ -341,7 +343,7 @@ class LabelInferenceThreatModel(TrainableThreatModel):
             self.atk_know_gen(ds) for ds in self.iterator_tracker(training_datasets)
         ]
         # Add the entries generated to the memory.
-        if not ignore_memory:
+        if use_memory:
             self._memory[training] = (
                 mem_datasets + gen_datasets,
                 mem_labels + gen_labels,

--- a/prive/threat_models/mia.py
+++ b/prive/threat_models/mia.py
@@ -75,12 +75,16 @@ class MIALabeller(AttackerKnowledgeWithLabel):
         labels (arbitrary ints or bools).
 
         """
+        if self.generate_pairs and num_samples // 2:
+            num_samples += 1  # Make num_samples dividable by 1.
         # Generate the datasets from the attacker knowledge.
-        datasets = self.attacker_knowledge.generate_datasets(num_samples, training)
+        datasets = self.attacker_knowledge.generate_datasets(
+            num_samples // 2 if self.generate_pairs else num_samples, training
+        )
         if self.generate_pairs:
             # If pairs are required, duplicate the list and assign labels 0 and 1.
             datasets = datasets + datasets
-            labels = [0] * num_samples + [1] * num_samples
+            labels = [0] * (num_samples // 2) + [1] * (num_samples // 2)
         else:
             # Pick random labels for each dataset.
             labels = list(np.random.random(size=(num_samples,)) <= 0.5)
@@ -100,7 +104,6 @@ class MIALabeller(AttackerKnowledgeWithLabel):
     @property
     def label(self):
         return self.attacker_knowledge.label
-    
 
 
 class TargetedMIA(LabelInferenceThreatModel):
@@ -146,8 +149,8 @@ class TargetedMIA(LabelInferenceThreatModel):
         return MIAttackSummary(
             truth_labels,
             pred_labels,
-            generator_info = self.atk_know_gen.label,
-            attack_info = attack.label,
-            dataset_info = self.atk_know_data.label,
-            target_id = self.target_record.label,
+            generator_info=self.atk_know_gen.label,
+            attack_info=attack.label,
+            dataset_info=self.atk_know_data.label,
+            target_id=self.target_record.label,
         )

--- a/prive/threat_models/mia.py
+++ b/prive/threat_models/mia.py
@@ -144,8 +144,8 @@ class TargetedMIA(LabelInferenceThreatModel):
         )
         # Post-process this as a MIAttackSummary.
         return MIAttackSummary(
-            pred_labels,
             truth_labels,
+            pred_labels,
             generator_info = self.atk_know_gen.label,
             attack_info = attack.label,
             dataset_info = self.atk_know_data.label,


### PR DESCRIPTION
This PR implements a diversity of attacks, and in particular AIAs. It also fixes some bugs in `prive` and adds a page of documentation describing the attacks implemented in the library and how to apply them. Finally, this also adds an example for attribute inference attacks.

This closes issue #86.