### PR TITLE
Multiply targeted attacks

### DIFF
--- a/prive/datasets/dataset.py
+++ b/prive/datasets/dataset.py
@@ -361,6 +361,13 @@ class TabularDataset(Dataset):
             # drop n random records if none provided
             record_ids = np.random.choice(self.data.index, size=n).tolist()
 
+        else:
+            # TODO: the indices expected by pandas are the ones used by .loc,
+            # whereas in this file we use mostly .iloc. This needs to be
+            # cleaned in some way. At the moment, we renumber record_ids to
+            # be absolute indices (in 0, ..., len(dataset)-1).
+            record_ids = [self.data.index[i] for i in record_ids]
+
         new_data = self.data.drop(record_ids)
 
         if in_place:

--- a/prive/tests/test_threat_models.py
+++ b/prive/tests/test_threat_models.py
@@ -52,6 +52,7 @@ class TestMIA(TestCase):
             generate_pairs=generate_pairs,
             replace_target=replace_target,
         )
+        self.assertEqual(mia.multiple_label_mode, False)
         # Check that we generate the correct number of samples.
         num_samples = 100
         datasets, labels = mia.generate_training_samples(num_samples)
@@ -64,7 +65,7 @@ class TestMIA(TestCase):
             self.assertEqual(len(ds), 2 if (replace_target or not target_in) else 3)
             self.assertEqual(target_record in ds, target_in)
 
-    def test_labelling_basic(self):
+    def test_labelling_default(self):
         self._test_labelling_helper(False, False)
 
     def test_labelling_pairs(self):
@@ -110,6 +111,7 @@ class TestMIAMultipleTargets(TestCase):
             replace_target=replace_target,
             generate_pairs=generate_pairs,
         )
+        self.assertEqual(mia.multiple_label_mode, True)
         # Generate datasets and check the labelling.
         for r, threat_model_targeted in zip(target_records, mia):
             # Check that the target record is properly set.
@@ -139,7 +141,7 @@ class TestMIAMultipleTargets(TestCase):
                     self.assertGreater(len(ds), num_training_records)
                 self.assertEqual(r in ds, target_in)
 
-    def test_labelling_basic(self):
+    def test_labelling_default(self):
         self._test_multiple_targets(False, False)
 
     def test_labelling_pairs(self):

--- a/prive/threat_models/aia.py
+++ b/prive/threat_models/aia.py
@@ -36,7 +36,7 @@ class AIALabeller(AttackerKnowledgeWithLabel):
     def __init__(
         self,
         attacker_knowledge: AttackerKnowledgeOnData,
-        target_record: TabularRecord,
+        target_records: TabularRecord,
         sensitive_attribute: str,
         attribute_values: list,
         distribution: list = None,
@@ -49,8 +49,10 @@ class AIALabeller(AttackerKnowledgeWithLabel):
         ----------
         attacker_knowledge: AttackerKnowledgeOnData
             The data knowledge from which datasets are generated.
-        target_record: Dataset
-            The target record to add to the dataset.
+        target_records: Dataset
+            The target records to add to the dataset with different sensitive
+            attribute values. If this contains more than one record, the values
+            for each record is sampled independently from all others.
         sensitive_attribute: str
             The name of the attribute to randomise.
         attribute_values: list
@@ -61,7 +63,7 @@ class AIALabeller(AttackerKnowledgeWithLabel):
             distribution is used.
         """
         self.attacker_knowledge = attacker_knowledge
-        self.target_record = target_record
+        self.target_records = target_records
         self.sensitive_attribute = sensitive_attribute
         self.attribute_values = attribute_values
         self.distribution = distribution
@@ -76,29 +78,42 @@ class AIALabeller(AttackerKnowledgeWithLabel):
         """
         # Generate the datasets from the attacker knowledge.
         datasets = self.attacker_knowledge.generate_datasets(num_samples, training)
-        # Sample target attributes iid.
-        labels = list(
+        # Sample target attributes i.i.d. for each record and dataset.
+        all_labels = list(
             np.random.choice(
                 self.attribute_values,
-                size=(num_samples,),
+                size=(num_samples, len(self.target_records)),
                 replace=True,
                 p=self.distribution,
             )
         )
-        # Modify the record with all possible values, and save.
-        modified_records = {}
-        for value in self.attribute_values:
-            r = self.target_record.copy()
-            r.set_value(self.sensitive_attribute, value)
-            modified_records[value] = r
+        # Modify the records with all possible values, and save the resulting
+        # records for efficiency purposes.
+        modified_records = []
+        for r in self.target_records:
+            L = {}
+            for value in self.attribute_values:
+                r = r.copy()
+                r.set_value(self.sensitive_attribute, value)
+                L[value] = r
+            modified_records.append(L)
+        # For each dataset, remove random records and add the modified records.
+        mod_datasets = []
+        for ds, labels in zip(datasets, all_labels):
+            # Remove random entries from the dataset, all at once (so as to avoid
+            # removing records added from target_records).
+            ds = ds.drop_records(
+                np.random.choice(len(ds), size=len(self.target_records), replace=False)
+            )
+            # Add records one by one, with corresponding label.
+            for r, v, mod_r in zip(self.target_records, labels, modified_records):
+                ds.add_records(mod_r[v], in_place=True)
+            mod_datasets.append(ds)
+        # Convert labels to a 1-dimensional list if only one target record is given.
+        if len(self.target_records) == 1:
+            all_labels = [l[0] for l in all_labels]
         # Replace the records in each dataset, and return the labels.
-        return (
-            [
-                ds.replace(modified_records[v], in_place=False)
-                for ds, v in zip(datasets, labels)
-            ],
-            labels,
-        )
+        return mod_datasets, all_labels
 
 
 class TargetedAIA(LabelInferenceThreatModel):
@@ -111,7 +126,7 @@ class TargetedAIA(LabelInferenceThreatModel):
     def __init__(
         self,
         attacker_knowledge_data: AttackerKnowledgeOnData,
-        target_record: TabularRecord,
+        target_records: TabularDataset,
         sensitive_attribute: str,
         attribute_values: list,
         attacker_knowledge_generator: AttackerKnowledgeOnGenerator,
@@ -123,7 +138,7 @@ class TargetedAIA(LabelInferenceThreatModel):
             self,
             AIALabeller(
                 attacker_knowledge_data,
-                target_record,
+                target_records,
                 sensitive_attribute,
                 attribute_values,
                 distribution,
@@ -131,8 +146,25 @@ class TargetedAIA(LabelInferenceThreatModel):
             attacker_knowledge_generator,
             memorise_datasets,
             iterator_tracker=iterator_tracker,
+            num_labels=len(target_records),
         )
-        self.target_record = target_record
         self.sensitive_attribute = sensitive_attribute
         self.attribute_values = attribute_values
         self.distribution = distribution
+        # See mia.py for the following bit of code.
+        if self.multiple_label_mode:
+            self._target_records = [r for r in target_records]
+            self.set_label(0)
+        else:
+            self.target_record = target_records
+
+
+    def set_label(self, label):
+        """
+        If the attack is performed against multiple targets, this sets the
+        target record to use when outputting labels.
+
+        """
+        # See mia.py for the following bit of code.
+        LabelInferenceThreatModel.set_label(self, label)
+        self.target_record = self._target_records[label]

--- a/prive/threat_models/attacker_knowledge.py
+++ b/prive/threat_models/attacker_knowledge.py
@@ -148,7 +148,7 @@ class AuxiliaryDataKnowledge(AttackerKnowledgeOnData):
             self.test_data = dataset.copy()
             self.aux_data = self.test_data.create_subsets(
                 n=1, sample_size=aux_size, drop_records=True
-            ) [0]
+            )[0]
             # Add other specified datasets, if any.
             if aux_data is not None:
                 self.aux_data = self.aux_data + aux_data
@@ -268,12 +268,31 @@ class BlackBoxKnowledge(AttackerKnowledgeOnGenerator):
 
 
 class LabelInferenceThreatModel(TrainableThreatModel):
+    """
+    Label-inference Threat Model.
+
+    Many threat models take the following form: given knowledge on the dataset
+    and the method, for a given sensitive predicate phi, generate training
+    datasets with diverse values of phi (in order to train a model to infer
+    phi(real_data) from synthetic data). For MIAs, phi is membership, i.e., 
+    I{x in data}, while for AIAs, phi is the value of the sensitive attribute
+    of the target.
+
+    This threat model abstracts such threat models by assuming that the
+    knowledge on the dataset generates *labelled* datasets. This label can be
+    anything. To implement specific threat models, it is recommended to create
+    a AttackerKnowledgeWithLabel objects that wraps a AttackerKnowledge object
+    to generate datasets that fit some labels. See, e.g., mia.py for an example.
+
+    """
+
     def __init__(
         self,
         attacker_knowledge_data: AttackerKnowledgeWithLabel,
         attacker_knowledge_generator: AttackerKnowledgeOnGenerator,
         memorise_datasets=True,
         iterator_tracker: Callable[[list], Iterable] = None,
+        num_labels: int = 1,
     ):
         """
         Generate a Label-Inference Threat Model.
@@ -285,7 +304,7 @@ class LabelInferenceThreatModel(TrainableThreatModel):
             label that the attack aims to predict.
         attacker_knowledge_generator: AttackerKnowledgeOnGenerator
             The knowledge on the generator available to the attacker.
-        memorise_datasets: True
+        memorise_datasets: boolean, default True
             Whether to memoise the synthetic datasets generated,
         iterator_tracker: Callable list L -> Iterable over L.
             A callable used to track iterations. The method __next__ is called
@@ -293,6 +312,13 @@ class LabelInferenceThreatModel(TrainableThreatModel):
             progress, e.g. with tqdm. Default is lambda x: x (silent).
             Note that this iterator is only called for synthetic data generation,
             which is often the bottleneck, and not training data generation.
+        num_labels: int, default 1
+            Number of labels output by attacker_knowledge_data. If >1, the
+            labels are disaggregated and treated as multiple indepedent labels.
+            This enables "multiple-label" mode, where this object can be used
+            as a threat model against any one label at a time. This mode exists
+            for efficiency reasons, allowing the same synthetic datasets to be
+            reused for several threat models.
 
         """
         self.atk_know_data = attacker_knowledge_data
@@ -302,6 +328,14 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         self.iterator_tracker = iterator_tracker or (lambda x: x)
         # maps training = True/False -> list of datasets, list of labels.
         self._memory = {True: ([], []), False: ([], [])}
+        # Multiple-label mode.
+        self.num_labels = num_labels
+        self.multiple_label_mode = num_labels > 1
+        if self.multiple_label_mode:
+            # Multiple-label mode: all interactions with this object occur as
+            # if there was only one label: the `self.current_label`th entry
+            # in the label vector returned by samples.
+            self.current_label = 0
 
     def _generate_samples(
         self, num_samples: int, training: bool = True, ignore_memory: bool = False,
@@ -311,6 +345,10 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         two lists, the first of synthetic datasets and the second of labels (1 if
         the target is in the training dataset used to produce the corresponding
         dataset, and 0 otherwise).
+
+        If this object is in multiple label mode, then this modifies the output
+        to restrict labels to self.current_label. The memory retains the full
+        labels, and memoisation thus works across multiple labels.
 
         Parameters
         ----------
@@ -346,8 +384,13 @@ class LabelInferenceThreatModel(TrainableThreatModel):
                 mem_datasets + gen_datasets,
                 mem_labels + gen_labels,
             )
+        # Finally, if in multiple-label mode, filter labels to only current.
+        # This only changes the output of this function, and not the memory.
+        all_labels = mem_labels + gen_labels
+        if self.multiple_label_mode:
+            all_labels = [l[self.current_label] for l in all_labels]
         # Combine results from the memory with generated results.
-        return mem_datasets + gen_datasets, mem_labels + gen_labels
+        return mem_datasets + gen_datasets, all_labels
 
     def generate_training_samples(
         self, num_samples: int, ignore_memory: bool = False,
@@ -380,7 +423,7 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         num_samples : int
             Number of test datasets to generate and test against.
         ignore_memory: bool, default False
-            Whether to use the memoized datasets, or ignore them.
+            Whether to ignore the memoized datasets. Not recommended.
 
         Returns
         -------
@@ -394,3 +437,40 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         )
         pred_labels = attack.attack(test_datasets)
         return pred_labels, truth_labels
+
+    # For multiple-label mode: choosing the current label.
+    def set_label(self, label):
+        """
+        If in multiple label mode, set the *index* of the label to use.
+
+        label: int in {0, ..., self.num_labels-1}.
+            The index of the label to use when outputing datasets.
+
+        """
+        assert (
+            self.multiple_label_mode
+        ), "set_label cannot be used in single-label mode."
+        assert (
+            0 <= label < self.num_labels
+        ), "Label index must be between 0 and self.num_labels-1."
+        self.current_label = label
+
+    def __iter__(self):
+        """
+        In multiple label model, this *yields* itself, modified every time to
+        use a different label. DO NOT use this outside of a generator (e.g.,
+        do *not* list(threat_model)), only in loops.
+
+        Example use:
+            for tm in threat_model:
+                # This uses a different label!
+                attack.train(tm)
+                print(tm.test(attack))
+
+        Note that extensions of this class will often have additional data
+        about the current label, that can be accessed within the loop.
+
+        """
+        for label in range(self.num_labels):
+            self.set_label(label)
+            yield self

--- a/prive/threat_models/base_classes.py
+++ b/prive/threat_models/base_classes.py
@@ -52,6 +52,6 @@ class TrainableThreatModel(ThreatModel):
     def generate_training_samples(self, num_samples):
         """
         Generate synthetic datasets (and potentially associated labels) to
-        train an attacl.
+        train an attack.
 
         """

--- a/prive/threat_models/mia.py
+++ b/prive/threat_models/mia.py
@@ -100,7 +100,7 @@ class MIALabeller(AttackerKnowledgeWithLabel):
                 dataset2 = dataset.copy()
             # For each target, assign a random label.
             labels = np.random.randint(2, size=len(self.target_records)) == 1
-            # If replace_target, then we first remove entries for
+            # If replace_target, then we first remove entries for the targets.
             if self.replace_target:
                 # We first choose an entry e for each target record such that if
                 # the target x is in the data, then e is removed (and vice versa).
@@ -122,7 +122,7 @@ class MIALabeller(AttackerKnowledgeWithLabel):
                         in_place=True,
                         n=0,  # Same as above.
                     )
-            #
+            # Add the target records.
             for record, label in zip(self.target_records, labels):
                 # If the label is 1, modify dataset.
                 if label:

--- a/prive/threat_models/mia.py
+++ b/prive/threat_models/mia.py
@@ -42,7 +42,7 @@ class MIALabeller(AttackerKnowledgeWithLabel):
     def __init__(
         self,
         attacker_knowledge: AttackerKnowledgeOnData,
-        target_record: Dataset,
+        target_records: Dataset,
         generate_pairs=True,
         replace_target=False,
     ):
@@ -54,16 +54,22 @@ class MIALabeller(AttackerKnowledgeWithLabel):
         attacker_knowledge: AttackerKnowledgeOnData
             The data knowledge from which datasets are generated.
         target_record: Dataset
-            The target record to append half of the time.
+            The target record to append half of the time. This dataset can
+            contain more than one record, in which case the records are
+            randomly added independently of one another.
         generate_pairs: bool, default True
-            Whether to output pairs of datasets (positive and negative) or
-            randomly choose for each dataset.
+            Whether to output pairs of datasets differing only by the presence
+            of the target record, or randomly choose for each dataset.
+            If multiple targets are provided, then the pairs of datasets differ
+            by exactly all of the multiple targets (as in, if a record x from
+            the targets is in D, it is not in D', but the membership of each
+            target is independent from the other targets).
         replace_target: bool, default False
             Whether to replace a record, instead of appending.
 
         """
         self.attacker_knowledge = attacker_knowledge
-        self.target_record = target_record
+        self.target_records = target_records
         self.generate_pairs = generate_pairs
         self.replace_target = replace_target
 
@@ -75,32 +81,71 @@ class MIALabeller(AttackerKnowledgeWithLabel):
         labels (arbitrary ints or bools).
 
         """
+        # If generating pairs, make num_samples dividable by 2.
+        if self.generate_pairs and num_samples // 2:
+            num_samples += 1
+
         # Generate the datasets from the attacker knowledge.
-        datasets = self.attacker_knowledge.generate_datasets(num_samples, training)
-        if self.generate_pairs:
-            # If pairs are required, duplicate the list and assign labels 0 and 1.
-            datasets = datasets + datasets
-            labels = [0] * num_samples + [1] * num_samples
-        else:
-            # Pick random labels for each dataset.
-            labels = list(np.random.random(size=(num_samples,)) <= 0.5)
-        # Produce a list of datasets with appended target where label = 1.
-        app_datasets = [
-            (
-                ds.replace(self.target_record)
-                if self.replace_target
-                else ds.add_records(self.target_record)
-            )
-            if l
-            else ds
-            for ds, l in zip(datasets, labels)
-        ]
-        return app_datasets, labels
+        datasets = self.attacker_knowledge.generate_datasets(
+            num_samples // 2 if self.generate_pairs else num_samples, training
+        )
+
+        # Compute modified datasets and corresponding labels by adding records
+        # according to the labels. If self.generate_pairs, each iteration of
+        # the loop creates two paired datasets.
+        app_datasets = []
+        app_labels = []
+        for i_ds, dataset in enumerate(datasets):
+            # Copy the datasets to be modified in place.
+            dataset = dataset.copy()
+            if self.generate_pairs:
+                dataset2 = dataset.copy()
+            # For each target, assign a random label.
+            labels = np.random.randint(2, size=len(self.target_records)) == 1
+            # If replace_target, then we first remove entries for
+            if self.replace_target:
+                # We first choose an entry e for each target record such that if
+                # the target x is in the data, then e is removed (and vice versa).
+                # This is to avoid replacing other target records. The reason we
+                # do not use .replace_records is to be able to generate pairs.
+                replace_indices = np.random.choice(
+                    len(dataset), size=len(self.target_records), replace=False
+                )
+                # Remove the indices where label=1.
+                dataset.drop_records(
+                    [idx for idx, l in zip(replace_indices, labels) if l],
+                    in_place=True,
+                    n=0,  # Ensures that no records are dropped if the list is empty.
+                )
+                if self.generate_pairs:
+                    # If generating pairs, remove indices where label=0 in dataset2.
+                    dataset2.drop_records(
+                        [idx for idx, l in zip(replace_indices, labels) if not l],
+                        in_place=True,
+                        n=0,  # Same as above.
+                    )
+            #
+            for record, label in zip(self.target_records, labels):
+                # If the label is 1, modify dataset.
+                if label:
+                    dataset.add_records(record, in_place=True)
+                # If generating pairs and the label is 0, the label is 1 for
+                # the other dataset in the pair. Modify dataset2
+                elif self.generate_pairs:
+                    dataset2.add_records(record, in_place=True)
+            # Labels need to be converted, either as lists or int/float (if only one).
+            _convert = list if len(self.target_records) > 1 else lambda x: x[0]
+            app_datasets.append(dataset)
+            app_labels.append(_convert(labels))
+            if self.generate_pairs:
+                app_datasets.append(dataset2)
+                app_labels.append(_convert(labels == False))  # Negation.
+
+        return app_datasets, app_labels
 
     @property
     def label(self):
         return self.attacker_knowledge.label
-    
 
 
 class TargetedMIA(LabelInferenceThreatModel):
@@ -113,7 +158,7 @@ class TargetedMIA(LabelInferenceThreatModel):
     def __init__(
         self,
         attacker_knowledge_data: AttackerKnowledgeOnData,
-        target_record: Dataset,
+        target_records: Dataset,
         attacker_knowledge_generator: AttackerKnowledgeOnGenerator,
         generate_pairs: bool = True,
         replace_target: bool = False,
@@ -123,13 +168,23 @@ class TargetedMIA(LabelInferenceThreatModel):
         LabelInferenceThreatModel.__init__(
             self,
             MIALabeller(
-                attacker_knowledge_data, target_record, generate_pairs, replace_target
+                attacker_knowledge_data, target_records, generate_pairs, replace_target
             ),
             attacker_knowledge_generator,
             memorise_datasets,
             iterator_tracker=iterator_tracker,
+            num_labels=len(target_records),
         )
-        self.target_record = target_record
+        # Save the target recordS, and the current record (0).
+        if self.multiple_label_mode:
+            # Since calling .get_records creates a new Dataset object every
+            # time, and involves indices, we instead compute the records once
+            # and for all.
+            self._target_records = [r for r in target_records]
+            # This sets self.target_record.
+            self.set_label(0)
+        else:
+            self.target_record = target_records
 
     # Wrap the test method to output a MIAttackSummary.
     def test(
@@ -146,8 +201,20 @@ class TargetedMIA(LabelInferenceThreatModel):
         return MIAttackSummary(
             pred_labels,
             truth_labels,
-            generator_info = self.atk_know_gen.label,
-            attack_info = attack.label,
-            dataset_info = self.atk_know_data.label,
-            target_id = self.target_record.label,
+            generator_info=self.atk_know_gen.label,
+            attack_info=attack.label,
+            dataset_info=self.atk_know_data.label,
+            target_id=self.target_record.label,
         )
+
+    def set_label(self, label):
+        """
+        If the attack is performed against multiple targets, this sets the
+        target record to use when outputting labels.
+
+        """
+        # Use the parent class's set_label. The main reason we override this
+        # method is to also modify self.target_record.
+        LabelInferenceThreatModel.set_label(self, label)
+        # We also set self.target_record, to be used by .
+        self.target_record = self._target_records[label]

--- a/prive/threat_models/mia.py
+++ b/prive/threat_models/mia.py
@@ -53,10 +53,10 @@ class MIALabeller(AttackerKnowledgeWithLabel):
         -----
         attacker_knowledge: AttackerKnowledgeOnData
             The data knowledge from which datasets are generated.
-        target_record: Dataset
-            The target record to append half of the time. This dataset can
-            contain more than one record, in which case the records are
-            randomly added independently of one another.
+        target_records: Dataset
+            The target records to append to the dataset. If several records
+            are provided, these records are randomly added to the dataset
+            independently from each other.
         generate_pairs: bool, default True
             Whether to output pairs of datasets differing only by the presence
             of the target record, or randomly choose for each dataset.
@@ -93,8 +93,8 @@ class MIALabeller(AttackerKnowledgeWithLabel):
         # Compute modified datasets and corresponding labels by adding records
         # according to the labels. If self.generate_pairs, each iteration of
         # the loop creates two paired datasets.
-        app_datasets = []
-        app_labels = []
+        mod_datasets = []
+        mod_labels = []
         for i_ds, dataset in enumerate(datasets):
             # Copy the datasets to be modified in place.
             dataset = dataset.copy()
@@ -135,13 +135,13 @@ class MIALabeller(AttackerKnowledgeWithLabel):
                     dataset2.add_records(record, in_place=True)
             # Labels need to be converted, either as lists or int/float (if only one).
             _convert = list if len(self.target_records) > 1 else lambda x: x[0]
-            app_datasets.append(dataset)
-            app_labels.append(_convert(labels))
+            mod_datasets.append(dataset)
+            mod_labels.append(_convert(labels))
             if self.generate_pairs:
-                app_datasets.append(dataset2)
-                app_labels.append(_convert(labels == False))  # Negation.
+                mod_datasets.append(dataset2)
+                mod_labels.append(_convert(labels == False))  # Negation.
 
-        return app_datasets, app_labels
+        return mod_datasets, mod_labels
 
     @property
     def label(self):


### PR DESCRIPTION
Small PR that enables threat models (`TargetedMIA`, `TargetedAIA`) to support several targets at once. Since the main bottleneck of `prive` is in the generator, this allows the same synthetic datasets to be reused for different targets, making the toolbox more efficient.

Closes #88.