### PR TITLE
Add support for "Canary in the coalmine" examples in MIAs

### DIFF
--- a/examples/mia_with_canary.py
+++ b/examples/mia_with_canary.py
@@ -1,4 +1,4 @@
-from tapas.datasets.canary import produce_canary
+from tapas.datasets.canary import create_canary
 
 import tapas.datasets
 import tapas.generators
@@ -14,7 +14,7 @@ real_data = tapas.datasets.TabularDataset.read(
 # Create a *canary* record: this is a record with unique values for each
 # attribute. Creating this canary modifies the data description, and a new
 # dataset object (with the same content) is thus generated.
-data, canary = produce_canary(real_data)
+data, canary = create_canary(real_data)
 
 canary.set_id(-1)
 

--- a/examples/mia_with_canary.py
+++ b/examples/mia_with_canary.py
@@ -1,0 +1,63 @@
+from tapas.datasets.canary import produce_canary
+
+import tapas.datasets
+import tapas.generators
+import tapas.threat_models
+import tapas.attacks
+import tapas.report
+
+# Load the data.
+real_data = tapas.datasets.TabularDataset.read(
+    "data/2011 Census Microdata Teaching File", label="Census"
+)
+
+# Create a *canary* record: this is a record with unique values for each
+# attribute. Creating this canary modifies the data description, and a new
+# dataset object (with the same content) is thus generated.
+data, canary = produce_canary(real_data)
+
+canary.set_id(-1)
+
+# For comparison, we are also going to select a random record (0) as target.
+target = data.get_records([0])
+data.drop_records(record_ids=[0], in_place=True)
+
+# Since the target is a dataset, we can add the canary record to it to form
+# a dataset of two targets.
+targets = target.add_records(canary)
+
+generator = tapas.generators.Raw()
+
+# We use the same setup as groundhog_census.py.
+sdg_knowledge = tapas.threat_models.BlackBoxKnowledge(
+    generator, num_synthetic_records=5000,
+)
+
+data_knowledge = tapas.threat_models.AuxiliaryDataKnowledge(
+    data, auxiliary_split=0.5, num_training_records=5000,
+)
+
+threat_model = tapas.threat_models.TargetedMIA(
+    attacker_knowledge_data=data_knowledge,
+    target_record=targets,  # except with two targets!
+    attacker_knowledge_generator=sdg_knowledge,
+    replace_target=True,
+)
+
+# By iterating over a threat model, we cycle through the target users.
+# You can manually modify which user the threat model is trying to attack, but
+# iterating automatically does it for you.
+
+summaries = []
+for threat_model_for_a_target in threat_model:
+    attacker = tapas.attacks.GroundhogAttack()
+    attacker.train(
+        threat_model_for_a_target, num_samples=100,
+    )
+    summaries.append(threat_model_for_a_target.test(attacker))
+
+# Finally, group together the summaries as a report.
+reports = [tapas.report.MIAttackReport(summaries), tapas.report.ROCReport(summaries)]
+
+for report in reports:
+    report.publish("canary_mia")

--- a/tapas/datasets/canary.py
+++ b/tapas/datasets/canary.py
@@ -2,7 +2,7 @@
 from .dataset import TabularDataset, TabularRecord, DataDescription
 
 
-def produce_canary(dataset: TabularDataset):
+def create_canary(dataset: TabularDataset):
     """
     Create a "canary", a record which should stand out in the dataset and
     therefore is more likely to be identified in MIAs.
@@ -11,7 +11,9 @@ def produce_canary(dataset: TabularDataset):
     this record, and setting continuous attributes as the current maximum plus
     some margin.
 
-    This also creates a modified dataset with an updated description.
+    This also creates a modified dataset with an updated description. Importantly,
+    the canary is *not* part of the modified dataset, so it does not need to be
+    removed before passing the dataset to auxiliary knowledge.
 
     Parameters
     ----------

--- a/tapas/datasets/canary.py
+++ b/tapas/datasets/canary.py
@@ -1,0 +1,71 @@
+"""A set of utilities to do target selection and canaries."""
+from .dataset import TabularDataset, TabularRecord, DataDescription
+
+
+def produce_canary(dataset: TabularDataset):
+    """
+    Create a "canary", a record which should stand out in the dataset and
+    therefore is more likely to be identified in MIAs.
+
+    This works by adding new categories to the description that are unique to
+    this record, and setting continuous attributes as the current maximum plus
+    some margin.
+
+    This also creates a modified dataset with an updated description.
+
+    Parameters
+    ----------
+    dataset: TabularDataset
+        The dataset for which to generate a canary.
+
+    Returns
+    -------
+    new_dataset: TabularDataset
+        The input dataset with an updated description that takes the canary
+        into account. The content is unchanged, dataset.data = new_dataset.data.
+    record: TabularDataset
+        The canary. Use this record as target in MIAs.
+
+    """
+    # First, modify the description to allow the canary. This also computes the
+    # values to assign to the canary.
+    canary_values = []
+    new_schema = []
+    for column in dataset.description:
+        new_column = dict(column)
+        if column["type"].startswith("finite"):
+            # Integer: add one more value and increase the maximum.
+            if isinstance(column["representation"], int):
+                N = column["representation"]
+                new_column["representation"] = N + 1
+                canary_values.append(N)
+            # List of strings: add the string CANARY.
+            elif isinstance(column["representation"], list):
+                # TODO: check that this is not already in the acceptable keys.
+                new_key = "CANARY"
+                new_column["representation"] = column["representation"] + [new_key]
+                canary_values.append(new_key)
+            # Otherwise: this is weird.
+            else:
+                raise Exception(
+                    f"Unrecognised representation for type={column['type']}: {column['representation']}"
+                )
+        elif column["type"].startswith("real") or column["type"].startswith(
+            "countable"
+        ):
+            # Add a number larger than the current max.
+            new_max = dataset.data[column["name"]].max() + 1
+            canary_values.append(new_max)
+            # TODO: add string/datetime support.
+        elif column["type"] == "interval":
+            # Add the extremity of the interval.
+            canary_values.append(1)
+        else:
+            raise Exception(f"Unrecognised data type: {column['type']}.")
+        # Add the (potentially modified) new column.
+        new_schema.append(new_column)
+    # Second, create a dataset with the new description, and the canary from these values.
+    new_description = DataDescription(new_schema, dataset.description.label)
+    new_dataset = TabularDataset(dataset.data, new_description)
+    canary = TabularRecord([canary_values], new_description, "canary")
+    return new_dataset, canary

--- a/tapas/datasets/dataset.py
+++ b/tapas/datasets/dataset.py
@@ -212,10 +212,12 @@ class TabularDataset(Dataset):
         """
         Parameters
         ----------
-        data: pandas.DataFrame
+        data: pandas.DataFrame (or a valid argument for pd.DataFrame).
         description: tapas.datasets.data_description.DataDescription
         label: str (optional)
         """
+        if not isinstance(data, pd.DataFrame):
+            data = pd.DataFrame(data, columns = [c['name'] for c in description])
         self.data = data
         
         assert isinstance(description,DataDescription), 'description needs to be of class DataDescription'

--- a/tapas/tests/test_dataset.py
+++ b/tapas/tests/test_dataset.py
@@ -9,6 +9,7 @@ filterwarnings("ignore")
 
 from tapas.datasets import TabularDataset, TabularRecord
 from tapas.datasets.data_description import DataDescription
+from tapas.datasets.canary import create_canary
 
 
 class TestDescription(TestCase):
@@ -191,6 +192,10 @@ class TestTabularDataset(TestCase):
         rows = self.dataset.get_records(indices)
         for row in rows:
             self.assertIn(row, self.dataset)
+
+    def test_canary(self):
+        new_dataset, canary = create_canary(self.dataset)
+        self.assertEqual(new_dataset.description, canary.description)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces "canaries" -- pathological examples that can be produced from a dataset whose membership is more likely to be leaked in the real data.

Closes #116.