### PR TITLE
fix report not creating sub directories

### DIFF
--- a/tapas/report/utils.py
+++ b/tapas/report/utils.py
@@ -91,10 +91,13 @@ def metric_comparison_plots(
         )
         filename = f"{comparison_label}sComparison_Dataset{pair_name[0]}_Attack{pair_name[1]}.png"
 
-        if not os.path.exists(output_path):
-            os.makedirs(output_path)
+        filename = os.path.join(output_path, filename)
 
-        plt.savefig(os.path.join(output_path, filename))
+        dirname = os.path.dirname(filename)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        plt.savefig(filename)
 
         plt.close(fig)
 


### PR DESCRIPTION
Hello. The report fails with FileNotFoundError due to non-existing sub directories (e.g. "canary_mia/attacksComparison_Datasetresults/"). The original code only create directories from `output_path` (e.g. "canary_mia"), however `filename` can be a path with directories (e.g. "attacksComparison_Datasetresults/data (AUX)_AttackRaw.png"). With this commit we set prepend `output_path` to `filename`, create any missing parents, and save to `filename`.