### PR TITLE
remove `reprosyn` as a dep

### DIFF
--- a/examples/reprosyn.ipynb
+++ b/examples/reprosyn.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd4495c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "% pip install git+https://github.com/alan-turing-institute/reprosyn"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "017d81e0-0aba-4a82-a8d4-8c0bbb247248",
    "metadata": {},
@@ -9,7 +20,7 @@
     "\n",
     "This notebook provides an example of using `TAPAS's` generator class to generate census synthetic data using `reprosyn`.\n",
     "\n",
-    "We assume that you have installed reprosyn into whichever python environment you are working in using `pip install git+https://github.com/alan-turing-institute/reprosyn`.\n",
+    "We assume that you have installed reprosyn into whichever python environment you are working in using `pip install git+https://github.com/alan-turing-institute/reprosyn`. (if not, run the cell at the top of the notebook)\n",
     "\n",
     "First we load the census dataset."
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ Sphinx = {version = "^4.5.0", optional = true}
 sphinx-rtd-theme = {version = "^1.0.0", optional = true}
 tqdm = "^4.64.0"
 setuptools = "^65.5.0"
-reprosyn = {git = "https://github.com/alan-turing-institute/reprosyn", rev = "2b1f29ab582ca96d9adc8992bd8650f79248e5d1"}
 jupyterlab = "^3.5.0"
 nbclient = "0.5.13"
 


### PR DESCRIPTION
library did not explicitly depend on `reprosyn`, which comes with a bulky tensorflow dependency and causes problems for non-reprosyn uses