### PR TITLE
Asyncio sample generation

### DIFF
--- a/tapas/generators/generator.py
+++ b/tapas/generators/generator.py
@@ -25,6 +25,8 @@ class Generator(ABC):
         pass
 
     # The call method should map a dataset to a synthetic dataset.
+    # Subclasses can implement __call__ as a function or a coroutine. If coroutine is
+    # used then concurrency should be enabled in the threat model.
     def __call__(self, dataset, num_samples, **kwargs):
         self.fit(dataset, **kwargs)
         return self.generate(num_samples)

--- a/tapas/tests/test_threat_models.py
+++ b/tapas/tests/test_threat_models.py
@@ -308,8 +308,8 @@ class TestAttackerKnowledge(TestCase):
         gen = UncertainBoxKnowledge(
             Replicator(), 1, lambda: {"mean": np.random.normal()}, {"mean": 117}
         )
-        records_train = [gen(None, training_mode=True) for _ in range(1000)]
-        records_test = [gen(None, training_mode=False) for _ in range(1000)]
+        records_train = [gen(None, training_mode = True) for _ in range(1000)]
+        records_test = [gen(None, training_mode = False) for _ in range(1000)]
         self.assertTrue(np.mean(records_train) < 4)  # Unlikely to fail.
         self.assertTrue(np.std(records_train) < 2)
         for x in records_test:

--- a/tapas/tests/test_threat_models.py
+++ b/tapas/tests/test_threat_models.py
@@ -22,6 +22,7 @@ from tapas.threat_models import (
 )
 from tapas.generators import Raw, Generator
 
+
 class RawConcurrent(Raw):
     """A generator that's like Raw, but uses a coroutine to return results async."""
 
@@ -31,6 +32,7 @@ class RawConcurrent(Raw):
     @property
     def label(self):
         return "RawConcurrent"
+
 
 dummy_data_description = DataDescription(
     [
@@ -54,7 +56,9 @@ knowledge_on_data = AuxiliaryDataKnowledge(
     dataset, auxiliary_split=0.5, num_training_records=2
 )
 knowledge_on_sdg = BlackBoxKnowledge(Raw(), num_synthetic_records=None)
-knowledge_on_sdg_concurrent = BlackBoxKnowledge(RawConcurrent(), num_synthetic_records=None)
+knowledge_on_sdg_concurrent = BlackBoxKnowledge(
+    RawConcurrent(), num_synthetic_records=None
+)
 
 
 class TestMIA(TestCase):
@@ -63,7 +67,7 @@ class TestMIA(TestCase):
     def _test_labelling_helper(self, generate_pairs, replace_target, use_concurrency):
         """Test whether the datasets are correctly labelled."""
         atk_know = knowledge_on_sdg_concurrent if use_concurrency else knowledge_on_sdg
-        num_concurrent =  5 if use_concurrency else 1
+        num_concurrent = 5 if use_concurrency else 1
         mia = TargetedMIA(
             knowledge_on_data,
             target_record,

--- a/tapas/tests/test_threat_models.py
+++ b/tapas/tests/test_threat_models.py
@@ -64,9 +64,12 @@ knowledge_on_sdg_concurrent = BlackBoxKnowledge(
 class TestMIA(TestCase):
     """Test the membership-inference attack."""
 
-    def _test_labelling_helper(self, generate_pairs, replace_target, use_concurrency):
+    def _test_labelling_helper(self, generate_pairs, replace_target, async_generator, use_concurrency):
         """Test whether the datasets are correctly labelled."""
-        atk_know = knowledge_on_sdg_concurrent if use_concurrency else knowledge_on_sdg
+        if not async_generator and use_concurrency:
+            # This combination of parameters doesn't make sense.
+            return None
+        atk_know = knowledge_on_sdg_concurrent if async_generator else knowledge_on_sdg
         num_concurrent = 5 if use_concurrency else 1
         mia = TargetedMIA(
             knowledge_on_data,
@@ -90,28 +93,52 @@ class TestMIA(TestCase):
             self.assertEqual(target_record in ds, target_in)
 
     def test_labelling_default(self):
-        self._test_labelling_helper(False, False, False)
+        self._test_labelling_helper(False, False, False, False)
 
     def test_labelling_pairs(self):
-        self._test_labelling_helper(True, False, False)
+        self._test_labelling_helper(True, False, False, False)
 
     def test_labelling_replace(self):
-        self._test_labelling_helper(False, True, False)
+        self._test_labelling_helper(False, True, False, False)
 
     def test_labelling_replace_pairs(self):
-        self._test_labelling_helper(True, True, False)
+        self._test_labelling_helper(True, True, False, False)
 
-    def test_labelling_default_concurrent(self):
-        self._test_labelling_helper(False, False, True)
+    def test_labelling_default_async(self):
+        self._test_labelling_helper(False, False, True, False)
 
-    def test_labelling_pairs_concurrent(self):
-        self._test_labelling_helper(True, False, True)
+    def test_labelling_pairs_async(self):
+        self._test_labelling_helper(True, False, True, False)
 
-    def test_labelling_replace_concurrent(self):
-        self._test_labelling_helper(False, True, True)
+    def test_labelling_replace_async(self):
+        self._test_labelling_helper(False, True, True, False)
 
-    def test_labelling_replace_pairs_concurrent(self):
-        self._test_labelling_helper(True, True, True)
+    def test_labelling_replace_pairs_async(self):
+        self._test_labelling_helper(True, True, True, False)
+
+    def test_labelling_default_threads(self):
+        self._test_labelling_helper(False, False, False, True)
+
+    def test_labelling_pairs_threads(self):
+        self._test_labelling_helper(True, False, False, True)
+
+    def test_labelling_replace_threads(self):
+        self._test_labelling_helper(False, True, False, True)
+
+    def test_labelling_replace_pairs_threads(self):
+        self._test_labelling_helper(True, True, False, True)
+
+    def test_labelling_default_async_threads(self):
+        self._test_labelling_helper(False, False, True, True)
+
+    def test_labelling_pairs_async_threads(self):
+        self._test_labelling_helper(True, False, True, True)
+
+    def test_labelling_replace_async_threads(self):
+        self._test_labelling_helper(False, True, True, True)
+
+    def test_labelling_replace_pairs_async_threads(self):
+        self._test_labelling_helper(True, True, True, True)
 
 
 class TestMIAMultipleTargets(TestCase):

--- a/tapas/threat_models/aia.py
+++ b/tapas/threat_models/aia.py
@@ -138,6 +138,7 @@ class TargetedAIA(LabelInferenceThreatModel):
         distribution: list = None,
         memorise_datasets: bool = True,
         iterator_tracker: Callable[[list], Iterable] = None,
+        num_concurrent: int = 1,
     ):
         LabelInferenceThreatModel.__init__(
             self,
@@ -152,6 +153,7 @@ class TargetedAIA(LabelInferenceThreatModel):
             memorise_datasets,
             iterator_tracker=iterator_tracker,
             num_labels=len(target_record),
+            num_concurrent=num_concurrent,
         )
         self.sensitive_attribute = sensitive_attribute
         self.attribute_values = attribute_values

--- a/tapas/threat_models/attacker_knowledge.py
+++ b/tapas/threat_models/attacker_knowledge.py
@@ -267,7 +267,6 @@ class BlackBoxKnowledge(AttackerKnowledgeOnGenerator):
     def generate(self, training_dataset: Dataset, training_mode: bool = True):
         return self.generator(training_dataset, self.num_synthetic_records)
 
-
     @property
     def label(self):
         return self.generator.label

--- a/tapas/threat_models/attacker_knowledge.py
+++ b/tapas/threat_models/attacker_knowledge.py
@@ -481,7 +481,7 @@ class LabelInferenceThreatModel(TrainableThreatModel):
     def _sync_generate_data(
         self, training_datasets: list[Dataset], training: bool
     ) -> list[Dataset]:
-        """Generate synthetic data synchronously.
+        """Generate synthetic data sequentially (as opposed to concurrently).
 
         Parameters
         ----------

--- a/tapas/threat_models/attacker_knowledge.py
+++ b/tapas/threat_models/attacker_knowledge.py
@@ -350,11 +350,13 @@ class UncertainBoxKnowledge(AttackerKnowledgeOnGenerator):
 # where the attacker aims to infer the "label" of the private dataset. The
 # label is defined by the attacker's knowledge being AttackerKnowledgeWithLabel.
 
-class SilentIterator():
+
+class SilentIterator:
     """
     SilentIterator implements the interface expected of iteration trackers, but does
     nothing.
     """
+
     def __init__(self, *args, **kwargs):
         pass
 
@@ -444,8 +446,9 @@ class LabelInferenceThreatModel(TrainableThreatModel):
             # in the label vector returned by samples.
             self.current_label = 0
 
-    async def _async_generate_data(self, training_datasets: list[Dataset], training:
-                                   bool) -> list[Dataset]:
+    async def _async_generate_data(
+        self, training_datasets: list[Dataset], training: bool
+    ) -> list[Dataset]:
         """Generate synthetic data running multiple samples concurrently.
 
         Parameters
@@ -474,7 +477,9 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         tracker.close()
         return gen_datasets
 
-    def _sync_generate_data(self, training_datasets: list[Dataset], training: bool) -> list[Dataset]:
+    def _sync_generate_data(
+        self, training_datasets: list[Dataset], training: bool
+    ) -> list[Dataset]:
         """Generate synthetic data synchronously.
 
         Parameters
@@ -493,10 +498,13 @@ class LabelInferenceThreatModel(TrainableThreatModel):
         return gen_datasets
 
     def _generate_samples(
-        self, num_samples: int, training: bool = True, ignore_memory: bool = False,
+        self,
+        num_samples: int,
+        training: bool = True,
+        ignore_memory: bool = False,
     ) -> tuple[list[Dataset], list[bool]]:
         """
-        Internal method to generate samples for training or testing. This outputs 
+        Internal method to generate samples for training or testing. This outputs
         two lists, the first of synthetic datasets and the second of labels (1 if
         the target is in the training dataset used to produce the corresponding
         dataset, and 0 otherwise).

--- a/tapas/threat_models/mia.py
+++ b/tapas/threat_models/mia.py
@@ -160,7 +160,8 @@ class TargetedMIA(LabelInferenceThreatModel):
         generate_pairs: bool = True,
         replace_target: bool = False,
         memorise_datasets: bool = True,
-        iterator_tracker: Callable[[list], Iterable] = None,
+        iterator_tracker: Option[type] = None,
+        num_concurrent: int = 1,
     ):
         LabelInferenceThreatModel.__init__(
             self,
@@ -171,6 +172,7 @@ class TargetedMIA(LabelInferenceThreatModel):
             memorise_datasets,
             iterator_tracker=iterator_tracker,
             num_labels=len(target_record),
+            num_concurrent=num_concurrent,
         )
         # Save the target recordS, and the current record (0).
         if self.multiple_label_mode:


### PR DESCRIPTION
This PR allows the user to specify a data generator for which `__call__` is an asyncio coroutine rather than a function, and then use a new keyword argument `num_concurrent` when generating training/testing data to run the generation of multiple samples concurrently.

Note that this does _not_ implement parallelisation of the computing effort to generate synthetic data, unless the generation is run in external processes that look like I/O to the python process running TAPAS. This is not multiprocessing, merely asyncio. One sample generation task will run at a time, until one of them hits a long-running I/O task, during which it can yield control to other tasks. If the data generation isn't doing heavy I/O, this doesn't help performance.

The changes are backwards compatible; As long as one doesn't try to use coroutine generators or `num_concurrent>1`, everything should work as before.

I'll leave it to the package owner to decide whether it makes sense to have this in main, since I don't know if anyone other than our team is likely to use data generators that do heavy I/O (in our case talking to a SQL database).